### PR TITLE
Add minimal setup for building a .deb packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ compile_commands.json
 # Temp release folder
 releases/temp/*
 *.zip
+/debian/opt/d1-graphics-tool/icon.svg
+/debian/usr/bin/D1GraphicsTool

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Copy latest release build
+cp build-D1GraphicsTool-Desktop_Qt_6_2_4_GCC_64bit-Release/D1GraphicsTool debian/usr/bin/
+# Strip symbols
+strip -s debian/usr/bin/D1GraphicsTool
+
+# Copy short cut icon
+cp source/icon.svg debian/opt/d1-graphics-tool/
+
+# Build .deb package
+dpkg-deb --build debian
+
+# Rename package
+mv debian.deb d1-graphics-tool.deb

--- a/debian/DEBIAN/control
+++ b/debian/DEBIAN/control
@@ -1,0 +1,10 @@
+Package: d1-graphics-tool
+Version: 0.5.0
+Architecture: amd64
+Maintainer: Anders Jenbo <anders@jenbo.dk>
+Installed-Size: 444
+Depends: libqt6widgets6 (>= 6.2.4), qt6-qpa-plugins (>= 6.2.4)
+Section: graphics
+Priority: optional
+Homepage: https://github.com/savagesteel/d1-graphics-tool
+Description: Diablo 1 Graphics Tool can open CEL/CL2 graphics files and display them with chosen color palette (PAL) and color translation (TRN) files.

--- a/debian/usr/share/applications/D1GraphicsTool.desktop
+++ b/debian/usr/share/applications/D1GraphicsTool.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=0.5.0
+Type=Application
+Name=Diablo 1 Graphics Tool
+Comment=Work with Diablo 1 graphics files
+Keywords=Diablo;graphic;
+Exec=D1GraphicsTool
+Icon=/opt/d1-graphics-tool/icon.svg
+Terminal=false
+Categories=Graphics;2DGraphics;RasterGraphics;
+StartupNotify=true


### PR DESCRIPTION
Setup used to produce the deb package found in https://github.com/savagesteel/d1-graphics-tool/issues/13

Only caveat is that you need to build against Qt 6.2.4 (probably older will also work).

Current Qt Creatore will download Qt 6.3.1, but you can run the Qt Maintanance application to specify with SDK it should download (you can have multiple ones installed at the same time)

![image](https://user-images.githubusercontent.com/204594/183501026-13de16b0-11b7-485d-aa1c-fcb9620c2839.png)
