### PR TITLE
fix handling of the frame header

### DIFF
--- a/source/d1celframe.cpp
+++ b/source/d1celframe.cpp
@@ -24,6 +24,7 @@ bool D1CelFrame::load(QByteArray rawData)
     quint32 frameDataStartOffset = 0;
 
     // Checking the presence of the {CEL FRAME HEADER}
+    this->width = 0;
     if ((quint8)rawData[0] == 0x0A && (quint8)rawData[1] == 0x00) {
         frameDataStartOffset += 0x0A;
         // If header is present, try to compute frame width from frame header

--- a/source/d1cl2.cpp
+++ b/source/d1cl2.cpp
@@ -51,8 +51,11 @@ bool D1Cl2Frame::load(QByteArray rawData)
 
     quint32 frameDataStartOffset = 0;
 
-    frameDataStartOffset += (quint16)rawData[0];
-    this->width = this->computeWidthFromHeader(rawData);
+    this->width = 0;
+    if ((quint8)rawData[0] == 0x0A && (quint8)rawData[1] == 0x00) {
+        frameDataStartOffset += 0x0A;
+        this->width = this->computeWidthFromHeader(rawData);
+    }
 
     if (this->width == 0)
         return false;


### PR DESCRIPTION
- reset width in D1CelFrame::load, otherwise the value from previous load might be used
- validate header of cl2 files and fix its size on big-endian systems