### PR TITLE
Add support for building with Qt5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(QT NAMES Qt6 REQUIRED COMPONENTS Widgets)
-find_package(Qt6 REQUIRED COMPONENTS Widgets)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
 
 set(PROJECT_SOURCES
         source/celview.cpp
@@ -65,13 +65,20 @@ set(PROJECT_SOURCES
         source/D1GraphicsTool.rc
 )
 
-qt_add_executable(D1GraphicsTool
-	source/d1files.qrc
-	MANUAL_FINALIZATION
-	${PROJECT_SOURCES}
-)
+if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)
+    qt_add_executable(D1GraphicsTool
+        source/d1files.qrc
+        MANUAL_FINALIZATION
+        ${PROJECT_SOURCES}
+    )
+else()
+    add_executable(D1GraphicsTool
+        source/d1files.qrc
+        ${PROJECT_SOURCES}
+    )
+endif()
 
-target_link_libraries(D1GraphicsTool PRIVATE Qt6::Widgets)
+target_link_libraries(D1GraphicsTool PRIVATE Qt${QT_VERSION_MAJOR}::Widgets)
 
 set_target_properties(D1GraphicsTool PROPERTIES
     MACOSX_BUNDLE_GUI_IDENTIFIER d1-graphics-tool.savagesteel.net
@@ -85,4 +92,6 @@ install(TARGETS D1GraphicsTool
     BUNDLE DESTINATION .
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-qt_finalize_executable(D1GraphicsTool)
+if(QT_VERSION_MAJOR EQUAL 6)
+    qt_finalize_executable(D1GraphicsTool)
+endif()

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The tool now also supports PAL/TRN/SOL/AMP editing.
 
 ![Screenshot 1](/images/demo001.gif)
 
-This tool is cross-platform, it can be compiled on Windows, Linux, or macOS (using Qt Framework 6.1.2).  
+This tool is cross-platform, it can be compiled on Windows, Linux, or macOS (using the Qt5/6 Framework).  
 Go to the [releases page](https://github.com/savagesteel/d1-graphics-tool/releases) to download the latest build.
 
 ## Features

--- a/source/d1amp.cpp
+++ b/source/d1amp.cpp
@@ -1,6 +1,7 @@
 #include "d1amp.h"
 
 #include <QBuffer>
+#include <QDataStream>
 
 D1Amp::D1Amp(QString path)
 {
@@ -16,9 +17,11 @@ D1Amp::~D1Amp()
 bool D1Amp::load(QString ampFilePath, int allocate)
 {
     this->properties.clear();
-    this->properties.fill(0, allocate);
+    this->properties.reserve(allocate);
+    std::fill(this->properties.begin(), this->properties.end(), 0);
     this->types.clear();
-    this->types.fill(0, allocate);
+    this->types.reserve(allocate);
+    std::fill(this->types.begin(), this->types.end(), 0);
 
     // Opening AMP file with a QBuffer to load it in RAM
     if (!QFile::exists(ampFilePath))
@@ -42,8 +45,10 @@ bool D1Amp::load(QString ampFilePath, int allocate)
     QDataStream in(&fileBuffer);
     in.setByteOrder(QDataStream::LittleEndian);
 
-    this->types.fill(0, this->file.size());
-    this->properties.fill(0, this->file.size());
+    this->types.reserve(this->file.size());
+    std::fill(this->types.begin(), this->types.end(), 0);
+    this->properties.reserve(this->file.size());
+    std::fill(this->properties.begin(), this->properties.end(), 0);
     quint8 readBytr;
     for (int i = 0; i < this->file.size() / 2; i++) {
         in >> readBytr;

--- a/source/d1sol.cpp
+++ b/source/d1sol.cpp
@@ -1,6 +1,7 @@
 #include "d1sol.h"
 
 #include <QBuffer>
+#include <QDataStream>
 
 D1Sol::D1Sol(QString path)
 {
@@ -15,7 +16,8 @@ D1Sol::~D1Sol()
 
 bool D1Sol::load(QString solFilePath)
 {
-    this->subProperties.fill(0, 1);
+    this->subProperties.reserve(1);
+    std::fill(this->subProperties.begin(), this->subProperties.end(), 0);
 
     // Opening SOL file with a QBuffer to load it in RAM
     if (!QFile::exists(solFilePath))

--- a/source/palettewidget.h
+++ b/source/palettewidget.h
@@ -3,6 +3,7 @@
 #include <QDirIterator>
 #include <QGraphicsScene>
 #include <QJsonObject>
+#include <QMouseEvent>
 #include <QUndoCommand>
 #include <QWidget>
 
@@ -119,6 +120,7 @@ public:
 
     // Coordinates functions
     QRectF getColorCoordinates(quint8);
+    QPointF getMousePosition(QMouseEvent *mouseEvent);
     quint8 getColorIndexFromCoordinates(QPointF);
 
     // Mouse event filter


### PR DESCRIPTION
Qt6 dropped support for some platforms like Windows 32bit which some notable users are still using. Also many Linux distros still do not have Qt6 available.

It also turned out to be a fairly minor change to add comparability for both frameworks with CMake as in fact the default template has all of it setup for the build system so in the end it was just a handful of changes needed to the code.

![image](https://user-images.githubusercontent.com/204594/209213763-5435809a-0134-4acf-8756-3be11541ebd0.png)



