### PR TITLE
cleanup the handling of the D1Pal/Trn objects

### DIFF
--- a/source/d1pal.cpp
+++ b/source/d1pal.cpp
@@ -2,11 +2,6 @@
 
 #include <QTextStream>
 
-D1Pal::D1Pal(QString path)
-{
-    this->load(path);
-}
-
 D1Pal::~D1Pal()
 {
     delete[] colors;

--- a/source/d1pal.h
+++ b/source/d1pal.h
@@ -18,8 +18,10 @@ class D1Pal : public QObject {
     Q_OBJECT
 
 public:
+    static constexpr const char *DEFAULT_PATH = ":/default.pal";
+    static constexpr const char *DEFAULT_NAME = "_default.pal";
+
     D1Pal() = default;
-    D1Pal(QString);
     ~D1Pal();
 
     bool load(QString);

--- a/source/d1trn.cpp
+++ b/source/d1trn.cpp
@@ -1,9 +1,8 @@
 #include "d1trn.h"
 
-D1Trn::D1Trn(QString path, D1Pal *pal)
+D1Trn::D1Trn(D1Pal *pal)
     : palette(QPointer<D1Pal>(pal))
 {
-    this->load(path);
 }
 
 D1Trn::~D1Trn()

--- a/source/d1trn.h
+++ b/source/d1trn.h
@@ -11,8 +11,11 @@ class D1Trn : public QObject {
     Q_OBJECT
 
 public:
+    static constexpr const char *IDENTITY_PATH = ":/null.trn";
+    static constexpr const char *IDENTITY_NAME = "_null.trn";
+
     D1Trn() = default;
-    D1Trn(QString, D1Pal *);
+    D1Trn(D1Pal *pal);
     ~D1Trn();
 
     bool load(QString);

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -90,14 +90,14 @@ private:
     QPointer<SettingsDialog> settingsDialog = new SettingsDialog(this);
     QPointer<ExportDialog> exportDialog = new ExportDialog(this);
 
-    QPointer<D1Pal> pal = new D1Pal;
-    QPointer<D1Trn> trn1 = new D1Trn;
-    QPointer<D1Trn> trn2 = new D1Trn;
-    QPointer<D1CelBase> cel = new D1Cel;
-    QPointer<D1Min> min = new D1Min;
-    QPointer<D1Til> til = new D1Til;
-    QPointer<D1Sol> sol = new D1Sol;
-    QPointer<D1Amp> amp = new D1Amp;
+    QPointer<D1Pal> pal;
+    QPointer<D1Trn> trn1;
+    QPointer<D1Trn> trn2;
+    QPointer<D1CelBase> cel;
+    QPointer<D1Min> min;
+    QPointer<D1Til> til;
+    QPointer<D1Sol> sol;
+    QPointer<D1Amp> amp;
 
     QMap<QString, D1Pal *> pals;  // key: path, value: pointer to palette
     QMap<QString, D1Trn *> trn1s; // key: path, value: pointer to translation


### PR DESCRIPTION
- add consts for default.pal and null.trn
- split load from the constructors (load might fail)
- do not create empty instances when a MainWindow is created
- do not discard palette/trn if save/load fails (it might be just a permission issue)
- no need to set this->trn1/trn2/pal in the on_action*_triggered functions (Widget->selectPath should set it)
- always check the result of load/save in the on_action*_triggered functions
- getSelectedPath should never return empty + check against the new consts instead of startsWith