### PR TITLE
minor adjustments/fixes

### DIFF
--- a/source/d1cel.cpp
+++ b/source/d1cel.cpp
@@ -133,7 +133,7 @@ bool D1Cel::load(QString celFilePath, OpenAsParam *params)
         fileBuffer.seek(offset.first);
         QByteArray celFrameRawData = fileBuffer.read(offset.second - offset.first);
 
-        std::unique_ptr<D1CelFrameBase> frame { new D1CelFrame };
+        std::unique_ptr<D1CelFrameBase> frame { new D1CelFrame() };
         frame->load(celFrameRawData, params);
         this->frames.append(frame.release());
     }

--- a/source/d1cl2.cpp
+++ b/source/d1cl2.cpp
@@ -293,5 +293,5 @@ bool D1Cl2::load(QString cl2FilePath, OpenAsParam *params)
 
 D1Cl2Frame *D1Cl2::createFrame()
 {
-    return new D1Cl2Frame;
+    return new D1Cl2Frame();
 }

--- a/source/d1trn.h
+++ b/source/d1trn.h
@@ -38,5 +38,5 @@ private:
     QFile file;
     quint8 *translations = new quint8[D1TRN_TRANSLATIONS];
     QPointer<D1Pal> palette;
-    QPointer<D1Pal> resultingPalette = new D1Pal;
+    QPointer<D1Pal> resultingPalette = new D1Pal();
 };

--- a/source/levelcelview.h
+++ b/source/levelcelview.h
@@ -104,7 +104,7 @@ private:
     void updateSolProperty();
 
     Ui::LevelCelView *ui;
-    LevelCelScene *celScene = new LevelCelScene;
+    LevelCelScene *celScene = new LevelCelScene();
 
     D1CelBase *cel;
     D1Min *min;

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -39,27 +39,22 @@ MainWindow::MainWindow(QWidget *parent)
     this->ui->menuEdit->addAction(this->undoAction);
     this->ui->menuEdit->addAction(this->redoAction);
 
-    this->ui->menuPalette->setEnabled(false);
+    this->on_actionClose_triggered();
     setAcceptDrops(true);
 }
 
 MainWindow::~MainWindow()
 {
+    this->on_actionClose_triggered();
+
     delete ui;
     delete configuration;
+    delete openAsDialog;
     delete settingsDialog;
     delete exportDialog;
     delete this->undoStack;
     delete this->undoAction;
     delete this->redoAction;
-    delete this->pal;
-    delete this->trn1;
-    delete this->trn2;
-    delete this->cel;
-    delete this->min;
-    delete this->til;
-    delete this->amp;
-    delete this->sol;
     delete this->palHits;
 }
 
@@ -136,263 +131,6 @@ void MainWindow::loadConfiguration()
 void MainWindow::pushCommandToUndoStack(QUndoCommand *cmd)
 {
     this->undoStack->push(cmd);
-}
-
-void MainWindow::on_actionOpen_triggered()
-{
-    QString openFilePath = QFileDialog::getOpenFileName(
-        this, "Open Graphics", this->configuration->value("WorkingDirectory").toString(),
-        "CEL/CL2/CLX Files (*.cel *.CEL *.cl2 *.CL2 *.clx *.CLX)");
-
-    if (!openFilePath.isEmpty()) {
-        this->openFile(openFilePath);
-    }
-
-    // QMessageBox::information( this, "Debug", celFilePath );
-    // QMessageBox::information( this, "Debug", QString::number(cel->getFrameCount()));
-
-    // QTime timer = QTime();
-    // timer.start();
-    // QMessageBox::information( this, "time", QString::number(timer.elapsed()) );
-}
-
-void MainWindow::dragEnterEvent(QDragEnterEvent *event)
-{
-    if (event->mimeData()->hasFormat("text/uri-list"))
-        event->acceptProposedAction();
-}
-
-void MainWindow::dropEvent(QDropEvent *event)
-{
-    if (!event->mimeData()->hasFormat("text/uri-list"))
-        return;
-
-    event->acceptProposedAction();
-
-    for (const QUrl &url : event->mimeData()->urls())
-        this->openFile(url.toLocalFile());
-}
-
-void MainWindow::openFile(QString openFilePath, OpenAsParam *params)
-{
-    // Check file extension
-    if (params == nullptr && !openFilePath.toLower().endsWith(".cel")
-        && !openFilePath.toLower().endsWith(".cl2")
-        && !openFilePath.endsWith(".clx")) {
-        return;
-    }
-
-    this->on_actionClose_triggered();
-
-    this->ui->statusBar->showMessage("Loading...");
-    this->ui->statusBar->repaint();
-
-    // Loading default.pal
-    D1Pal *newPal = new D1Pal();
-    newPal->load(D1Pal::DEFAULT_PATH);
-    this->pals[D1Pal::DEFAULT_PATH] = newPal;
-    this->pal = newPal;
-
-    // Loading default null.trn
-    D1Trn *newTrn = new D1Trn(this->pal);
-    newTrn->load(D1Trn::IDENTITY_PATH);
-    this->trn1s[D1Trn::IDENTITY_PATH] = newTrn;
-    this->trn1 = newTrn;
-    newTrn = new D1Trn(this->trn1->getResultingPalette());
-    newTrn->load(D1Trn::IDENTITY_PATH);
-    this->trn2s[D1Trn::IDENTITY_PATH] = newTrn;
-    this->trn2 = newTrn;
-
-    QFileInfo celFileInfo = QFileInfo(openFilePath);
-
-    // If a SOL, MIN and TIL files exists then build a LevelCelView
-    QString basePath = celFileInfo.absolutePath() + "/" + celFileInfo.completeBaseName();
-    QString solFilePath = basePath + ".sol";
-    QString minFilePath = basePath + ".min";
-    QString tilFilePath = basePath + ".til";
-    bool isTileset = params == nullptr && QFileInfo::exists(solFilePath) && QFileInfo::exists(minFilePath) && QFileInfo::exists(tilFilePath);
-
-    QString extension = celFileInfo.suffix();
-    if (QString::compare(extension, "cel", Qt::CaseInsensitive) == 0) {
-        if (isTileset) {
-            // Loading SOL
-            this->sol = new D1Sol;
-            this->sol->load(solFilePath);
-
-            // Loading MIN
-            this->min = new D1Min;
-            if (!this->min->load(minFilePath, this->sol->getSubtileCount())) {
-                QMessageBox::critical(this, "Error", "Failed loading MIN file: " + minFilePath);
-                return;
-            }
-            this->cel = new D1CelTileset(this->min);
-            this->min->setCel(this->cel);
-
-            // Loading TIL
-            this->til = new D1Til;
-            if (!this->til->load(tilFilePath)) {
-                QMessageBox::critical(this, "Error", "Failed loading TIL file: " + tilFilePath);
-                return;
-            }
-            this->til->setMin(this->min);
-
-            // Loading AMP
-            this->amp = new D1Amp;
-            QString ampFilePath = basePath + ".amp";
-            this->amp->load(ampFilePath, this->min->getSubtileCount());
-        } else {
-            this->cel = new D1Cel;
-        }
-    } else if (QString::compare(extension, "cl2", Qt::CaseInsensitive) == 0) {
-        this->cel = new D1Cl2;
-    } else if (QString::compare(extension, "clx", Qt::CaseInsensitive) == 0) {
-        this->cel = new D1Clx;
-    }
-
-    if (!this->cel->load(openFilePath, params)) {
-        QMessageBox::critical(this, "Error", "Could not open " + extension.toUpper() + " file.");
-        return;
-    }
-
-    this->cel->setPalette(this->trn2->getResultingPalette());
-
-    // Add palette widgets for PAL and TRNs
-    this->palWidget = new PaletteWidget(this->configuration, nullptr, "Palette");
-    this->trn2Widget = new PaletteWidget(this->configuration, nullptr, "Translation");
-    this->trn1Widget = new PaletteWidget(this->configuration, nullptr, "Unique translation");
-    this->ui->palFrame->layout()->addWidget(this->palWidget);
-    this->ui->palFrame->layout()->addWidget(this->trn2Widget);
-    this->ui->palFrame->layout()->addWidget(this->trn1Widget);
-
-    // Configuration update triggers refresh of the palette widgets
-    QObject::connect(this->settingsDialog, &SettingsDialog::configurationSaved, this->palWidget, &PaletteWidget::reloadConfig);
-    QObject::connect(this->settingsDialog, &SettingsDialog::configurationSaved, this->trn1Widget, &PaletteWidget::reloadConfig);
-    QObject::connect(this->settingsDialog, &SettingsDialog::configurationSaved, this->trn2Widget, &PaletteWidget::reloadConfig);
-    QObject::connect(this->settingsDialog, &SettingsDialog::configurationSaved, this->palWidget, &PaletteWidget::refresh);
-
-    // Palette and translation file selection
-    // When a .pal or .trn file is selected in the PaletteWidget update the pal or trn
-    QObject::connect(this->palWidget, &PaletteWidget::pathSelected, this, &MainWindow::setPal);
-    QObject::connect(this->trn1Widget, &PaletteWidget::pathSelected, this, &MainWindow::setTrn1);
-    QObject::connect(this->trn2Widget, &PaletteWidget::pathSelected, this, &MainWindow::setTrn2);
-
-    // Refresh PAL/TRN view chain
-    QObject::connect(this->palWidget, &PaletteWidget::refreshed, this->trn1Widget, &PaletteWidget::refresh);
-    QObject::connect(this->trn1Widget, &PaletteWidget::refreshed, this->trn2Widget, &PaletteWidget::refresh);
-
-    // Translation color selection
-    QObject::connect(this->palWidget, &PaletteWidget::colorsSelected, this->trn2Widget, &PaletteWidget::checkTranslationsSelection);
-    QObject::connect(this->trn2Widget, &PaletteWidget::colorsSelected, this->trn1Widget, &PaletteWidget::checkTranslationsSelection);
-    QObject::connect(this->trn2Widget, &PaletteWidget::displayAllRootColors, this->palWidget, &PaletteWidget::temporarilyDisplayAllColors);
-    QObject::connect(this->trn1Widget, &PaletteWidget::displayAllRootColors, this->trn2Widget, &PaletteWidget::temporarilyDisplayAllColors);
-    QObject::connect(this->trn2Widget, &PaletteWidget::displayRootInformation, this->palWidget, &PaletteWidget::displayInfo);
-    QObject::connect(this->trn1Widget, &PaletteWidget::displayRootInformation, this->trn2Widget, &PaletteWidget::displayInfo);
-    QObject::connect(this->trn2Widget, &PaletteWidget::displayRootBorder, this->palWidget, &PaletteWidget::displayBorder);
-    QObject::connect(this->trn1Widget, &PaletteWidget::displayRootBorder, this->trn2Widget, &PaletteWidget::displayBorder);
-    QObject::connect(this->trn2Widget, &PaletteWidget::clearRootInformation, this->palWidget, &PaletteWidget::clearInfo);
-    QObject::connect(this->trn1Widget, &PaletteWidget::clearRootInformation, this->trn2Widget, &PaletteWidget::clearInfo);
-    QObject::connect(this->trn2Widget, &PaletteWidget::clearRootBorder, this->palWidget, &PaletteWidget::clearBorder);
-    QObject::connect(this->trn1Widget, &PaletteWidget::clearRootBorder, this->trn2Widget, &PaletteWidget::clearBorder);
-
-    // Send editing actions to the undo/redo stack
-    QObject::connect(this->palWidget, &PaletteWidget::sendEditingCommand, this, &MainWindow::pushCommandToUndoStack);
-    QObject::connect(this->trn1Widget, &PaletteWidget::sendEditingCommand, this, &MainWindow::pushCommandToUndoStack);
-    QObject::connect(this->trn2Widget, &PaletteWidget::sendEditingCommand, this, &MainWindow::pushCommandToUndoStack);
-
-    if (isTileset) {
-        this->levelCelView = new LevelCelView;
-        this->levelCelView->initialize(this->cel, this->min, this->til, this->sol, this->amp);
-
-        // Refresh CEL view if a PAL or TRN is modified
-        QObject::connect(this->palWidget, &PaletteWidget::modified, this->levelCelView, &LevelCelView::displayFrame);
-        QObject::connect(this->trn1Widget, &PaletteWidget::modified, this->levelCelView, &LevelCelView::displayFrame);
-        QObject::connect(this->trn2Widget, &PaletteWidget::modified, this->levelCelView, &LevelCelView::displayFrame);
-
-        // Select color when level CEL view clicked
-        QObject::connect(this->levelCelView, &LevelCelView::colorIndexClicked, this->palWidget, &PaletteWidget::selectColor);
-        QObject::connect(this->levelCelView, &LevelCelView::colorIndexClicked, this->trn1Widget, &PaletteWidget::selectColor);
-        QObject::connect(this->levelCelView, &LevelCelView::colorIndexClicked, this->trn2Widget, &PaletteWidget::selectColor);
-
-        // Refresh palette widgets when frame, subtile of tile is changed
-        QObject::connect(this->levelCelView, &LevelCelView::frameRefreshed, this->palWidget, &PaletteWidget::refresh);
-
-        // Initialize palette widgets
-        this->palHits = new D1PalHits(this->cel, this->min, this->til, this->sol);
-        this->palWidget->initialize(this->pal, this->levelCelView, this->palHits);
-        this->trn1Widget->initialize(this->pal, this->trn1, this->levelCelView, this->palHits);
-        this->trn2Widget->initialize(this->trn1->getResultingPalette(), this->trn2, this->levelCelView, this->palHits);
-
-        this->levelCelView->displayFrame();
-    }
-    // Otherwise build a CelView
-    else {
-        this->celView = new CelView;
-        this->celView->initialize(this->cel);
-
-        // Refresh CEL view if a PAL or TRN is modified
-        QObject::connect(this->palWidget, &PaletteWidget::modified, this->celView, &CelView::displayFrame);
-        QObject::connect(this->trn1Widget, &PaletteWidget::modified, this->celView, &CelView::displayFrame);
-        QObject::connect(this->trn2Widget, &PaletteWidget::modified, this->celView, &CelView::displayFrame);
-
-        // Select color when CEL view clicked
-        QObject::connect(this->celView, &CelView::colorIndexClicked, this->palWidget, &PaletteWidget::selectColor);
-        QObject::connect(this->celView, &CelView::colorIndexClicked, this->trn1Widget, &PaletteWidget::selectColor);
-        QObject::connect(this->celView, &CelView::colorIndexClicked, this->trn2Widget, &PaletteWidget::selectColor);
-
-        // Refresh palette widgets when frame
-        QObject::connect(this->celView, &CelView::frameRefreshed, this->palWidget, &PaletteWidget::refresh);
-
-        // Initialize palette widgets
-        this->palHits = new D1PalHits(this->cel);
-        this->palWidget->initialize(this->pal, this->celView, this->palHits);
-        this->trn1Widget->initialize(this->pal, this->trn1, this->celView, this->palHits);
-        this->trn2Widget->initialize(this->trn1->getResultingPalette(), this->trn2, this->celView, this->palHits);
-
-        this->celView->displayFrame();
-    }
-
-    // Look for all palettes in the same folder as the CEL/CL2 file
-    QDirIterator it(celFileInfo.absolutePath(), QStringList() << "*.pal", QDir::Files);
-    QString firstPaletteFound = QString();
-    while (it.hasNext()) {
-        QString sPath = it.next();
-
-        if (sPath != "1") {
-            QFileInfo palFileInfo(sPath);
-            QString path = palFileInfo.absoluteFilePath();
-            QString name = palFileInfo.fileName();
-            this->pals[path] = new D1Pal();
-
-            if (!this->pals[path]->load(path)) {
-                delete this->pals[path];
-                this->pals.remove(path);
-                QMessageBox::warning(this, "Warning", "Could not load PAL file.");
-                continue;
-            }
-
-            this->palWidget->addPath(path, name);
-
-            if (firstPaletteFound.isEmpty())
-                firstPaletteFound = path;
-        }
-    }
-    // Select the first palette found in the same folder as the CEL/CL2 if it exists
-    if (!firstPaletteFound.isEmpty())
-        this->palWidget->selectPath(firstPaletteFound);
-
-    // Adding the CelView to the main frame
-    if (this->celView != nullptr)
-        this->ui->mainFrame->layout()->addWidget(this->celView);
-    else
-        this->ui->mainFrame->layout()->addWidget(this->levelCelView);
-
-    // Adding the PalView to the pal frame
-    // this->ui->palFrame->layout()->addWidget( this->palView );
-    this->ui->menuPalette->setEnabled(true);
-    this->ui->actionExport->setEnabled(true);
-
-    // Clear loading message from status bar
-    this->ui->statusBar->clearMessage();
 }
 
 void MainWindow::paletteWidget_callback(PaletteWidget *widget, PWIDGET_CALLBACK_TYPE type)
@@ -474,6 +212,267 @@ void MainWindow::nextPaletteCycle(D1PAL_CYCLE_TYPE type)
     this->palWidget->modify();
 }
 
+void MainWindow::on_actionOpen_triggered()
+{
+    QString openFilePath = QFileDialog::getOpenFileName(
+        this, "Open Graphics", this->configuration->value("WorkingDirectory").toString(),
+        "CEL/CL2/CLX Files (*.cel *.CEL *.cl2 *.CL2 *.clx *.CLX)");
+
+    if (!openFilePath.isEmpty()) {
+        this->openFile(openFilePath);
+    }
+
+    // QMessageBox::information( this, "Debug", celFilePath );
+    // QMessageBox::information( this, "Debug", QString::number(cel->getFrameCount()));
+
+    // QTime timer = QTime();
+    // timer.start();
+    // QMessageBox::information( this, "time", QString::number(timer.elapsed()) );
+}
+
+void MainWindow::dragEnterEvent(QDragEnterEvent *event)
+{
+    if (event->mimeData()->hasFormat("text/uri-list"))
+        event->acceptProposedAction();
+}
+
+void MainWindow::dropEvent(QDropEvent *event)
+{
+    if (!event->mimeData()->hasFormat("text/uri-list"))
+        return;
+
+    event->acceptProposedAction();
+
+    for (const QUrl &url : event->mimeData()->urls())
+        this->openFile(url.toLocalFile());
+}
+
+void MainWindow::openFile(QString openFilePath, OpenAsParam *params)
+{
+    // Check file extension
+    if (params == nullptr && !openFilePath.toLower().endsWith(".cel")
+        && !openFilePath.toLower().endsWith(".cl2")
+        && !openFilePath.endsWith(".clx")) {
+        return;
+    }
+
+    this->on_actionClose_triggered();
+
+    this->ui->statusBar->showMessage("Loading...");
+    this->ui->statusBar->repaint();
+
+    // Loading default.pal
+    D1Pal *newPal = new D1Pal();
+    newPal->load(D1Pal::DEFAULT_PATH);
+    this->pals[D1Pal::DEFAULT_PATH] = newPal;
+    this->pal = newPal;
+
+    // Loading default null.trn
+    D1Trn *newTrn = new D1Trn(this->pal);
+    newTrn->load(D1Trn::IDENTITY_PATH);
+    this->trn1s[D1Trn::IDENTITY_PATH] = newTrn;
+    this->trn1 = newTrn;
+    newTrn = new D1Trn(this->trn1->getResultingPalette());
+    newTrn->load(D1Trn::IDENTITY_PATH);
+    this->trn2s[D1Trn::IDENTITY_PATH] = newTrn;
+    this->trn2 = newTrn;
+
+    QFileInfo celFileInfo = QFileInfo(openFilePath);
+
+    // If a SOL, MIN and TIL files exists then build a LevelCelView
+    QString basePath = celFileInfo.absolutePath() + "/" + celFileInfo.completeBaseName();
+    QString solFilePath = basePath + ".sol";
+    QString minFilePath = basePath + ".min";
+    QString tilFilePath = basePath + ".til";
+    bool isTileset = params == nullptr && QFileInfo::exists(solFilePath) && QFileInfo::exists(minFilePath) && QFileInfo::exists(tilFilePath);
+
+    QString extension = celFileInfo.suffix();
+    if (QString::compare(extension, "cel", Qt::CaseInsensitive) == 0) {
+        if (isTileset) {
+            // Loading SOL
+            this->sol = new D1Sol();
+            this->sol->load(solFilePath);
+
+            // Loading MIN
+            this->min = new D1Min();
+            if (!this->min->load(minFilePath, this->sol->getSubtileCount())) {
+                QMessageBox::critical(this, "Error", "Failed loading MIN file: " + minFilePath);
+                return;
+            }
+            this->cel = new D1CelTileset(this->min);
+            this->min->setCel(this->cel);
+
+            // Loading TIL
+            this->til = new D1Til();
+            if (!this->til->load(tilFilePath)) {
+                QMessageBox::critical(this, "Error", "Failed loading TIL file: " + tilFilePath);
+                return;
+            }
+            this->til->setMin(this->min);
+
+            // Loading AMP
+            this->amp = new D1Amp();
+            QString ampFilePath = basePath + ".amp";
+            this->amp->load(ampFilePath, this->min->getSubtileCount());
+        } else {
+            this->cel = new D1Cel();
+        }
+    } else if (QString::compare(extension, "cl2", Qt::CaseInsensitive) == 0) {
+        this->cel = new D1Cl2();
+    } else if (QString::compare(extension, "clx", Qt::CaseInsensitive) == 0) {
+        this->cel = new D1Clx();
+    }
+
+    if (!this->cel->load(openFilePath, params)) {
+        QMessageBox::critical(this, "Error", "Could not open " + extension.toUpper() + " file.");
+        return;
+    }
+
+    this->cel->setPalette(this->trn2->getResultingPalette());
+
+    // Add palette widgets for PAL and TRNs
+    this->palWidget = new PaletteWidget(this->configuration, nullptr, "Palette");
+    this->trn2Widget = new PaletteWidget(this->configuration, nullptr, "Translation");
+    this->trn1Widget = new PaletteWidget(this->configuration, nullptr, "Unique translation");
+    this->ui->palFrame->layout()->addWidget(this->palWidget);
+    this->ui->palFrame->layout()->addWidget(this->trn2Widget);
+    this->ui->palFrame->layout()->addWidget(this->trn1Widget);
+
+    // Configuration update triggers refresh of the palette widgets
+    QObject::connect(this->settingsDialog, &SettingsDialog::configurationSaved, this->palWidget, &PaletteWidget::reloadConfig);
+    QObject::connect(this->settingsDialog, &SettingsDialog::configurationSaved, this->trn1Widget, &PaletteWidget::reloadConfig);
+    QObject::connect(this->settingsDialog, &SettingsDialog::configurationSaved, this->trn2Widget, &PaletteWidget::reloadConfig);
+    QObject::connect(this->settingsDialog, &SettingsDialog::configurationSaved, this->palWidget, &PaletteWidget::refresh);
+
+    // Palette and translation file selection
+    // When a .pal or .trn file is selected in the PaletteWidget update the pal or trn
+    QObject::connect(this->palWidget, &PaletteWidget::pathSelected, this, &MainWindow::setPal);
+    QObject::connect(this->trn1Widget, &PaletteWidget::pathSelected, this, &MainWindow::setTrn1);
+    QObject::connect(this->trn2Widget, &PaletteWidget::pathSelected, this, &MainWindow::setTrn2);
+
+    // Refresh PAL/TRN view chain
+    QObject::connect(this->palWidget, &PaletteWidget::refreshed, this->trn1Widget, &PaletteWidget::refresh);
+    QObject::connect(this->trn1Widget, &PaletteWidget::refreshed, this->trn2Widget, &PaletteWidget::refresh);
+
+    // Translation color selection
+    QObject::connect(this->palWidget, &PaletteWidget::colorsSelected, this->trn2Widget, &PaletteWidget::checkTranslationsSelection);
+    QObject::connect(this->trn2Widget, &PaletteWidget::colorsSelected, this->trn1Widget, &PaletteWidget::checkTranslationsSelection);
+    QObject::connect(this->trn2Widget, &PaletteWidget::displayAllRootColors, this->palWidget, &PaletteWidget::temporarilyDisplayAllColors);
+    QObject::connect(this->trn1Widget, &PaletteWidget::displayAllRootColors, this->trn2Widget, &PaletteWidget::temporarilyDisplayAllColors);
+    QObject::connect(this->trn2Widget, &PaletteWidget::displayRootInformation, this->palWidget, &PaletteWidget::displayInfo);
+    QObject::connect(this->trn1Widget, &PaletteWidget::displayRootInformation, this->trn2Widget, &PaletteWidget::displayInfo);
+    QObject::connect(this->trn2Widget, &PaletteWidget::displayRootBorder, this->palWidget, &PaletteWidget::displayBorder);
+    QObject::connect(this->trn1Widget, &PaletteWidget::displayRootBorder, this->trn2Widget, &PaletteWidget::displayBorder);
+    QObject::connect(this->trn2Widget, &PaletteWidget::clearRootInformation, this->palWidget, &PaletteWidget::clearInfo);
+    QObject::connect(this->trn1Widget, &PaletteWidget::clearRootInformation, this->trn2Widget, &PaletteWidget::clearInfo);
+    QObject::connect(this->trn2Widget, &PaletteWidget::clearRootBorder, this->palWidget, &PaletteWidget::clearBorder);
+    QObject::connect(this->trn1Widget, &PaletteWidget::clearRootBorder, this->trn2Widget, &PaletteWidget::clearBorder);
+
+    // Send editing actions to the undo/redo stack
+    QObject::connect(this->palWidget, &PaletteWidget::sendEditingCommand, this, &MainWindow::pushCommandToUndoStack);
+    QObject::connect(this->trn1Widget, &PaletteWidget::sendEditingCommand, this, &MainWindow::pushCommandToUndoStack);
+    QObject::connect(this->trn2Widget, &PaletteWidget::sendEditingCommand, this, &MainWindow::pushCommandToUndoStack);
+
+    if (isTileset) {
+        this->levelCelView = new LevelCelView();
+        this->levelCelView->initialize(this->cel, this->min, this->til, this->sol, this->amp);
+
+        // Refresh CEL view if a PAL or TRN is modified
+        QObject::connect(this->palWidget, &PaletteWidget::modified, this->levelCelView, &LevelCelView::displayFrame);
+        QObject::connect(this->trn1Widget, &PaletteWidget::modified, this->levelCelView, &LevelCelView::displayFrame);
+        QObject::connect(this->trn2Widget, &PaletteWidget::modified, this->levelCelView, &LevelCelView::displayFrame);
+
+        // Select color when level CEL view clicked
+        QObject::connect(this->levelCelView, &LevelCelView::colorIndexClicked, this->palWidget, &PaletteWidget::selectColor);
+        QObject::connect(this->levelCelView, &LevelCelView::colorIndexClicked, this->trn1Widget, &PaletteWidget::selectColor);
+        QObject::connect(this->levelCelView, &LevelCelView::colorIndexClicked, this->trn2Widget, &PaletteWidget::selectColor);
+
+        // Refresh palette widgets when frame, subtile of tile is changed
+        QObject::connect(this->levelCelView, &LevelCelView::frameRefreshed, this->palWidget, &PaletteWidget::refresh);
+
+        // Initialize palette widgets
+        this->palHits = new D1PalHits(this->cel, this->min, this->til, this->sol);
+        this->palWidget->initialize(this->pal, this->levelCelView, this->palHits);
+        this->trn1Widget->initialize(this->pal, this->trn1, this->levelCelView, this->palHits);
+        this->trn2Widget->initialize(this->trn1->getResultingPalette(), this->trn2, this->levelCelView, this->palHits);
+
+        this->levelCelView->displayFrame();
+    }
+    // Otherwise build a CelView
+    else {
+        this->celView = new CelView();
+        this->celView->initialize(this->cel);
+
+        // Refresh CEL view if a PAL or TRN is modified
+        QObject::connect(this->palWidget, &PaletteWidget::modified, this->celView, &CelView::displayFrame);
+        QObject::connect(this->trn1Widget, &PaletteWidget::modified, this->celView, &CelView::displayFrame);
+        QObject::connect(this->trn2Widget, &PaletteWidget::modified, this->celView, &CelView::displayFrame);
+
+        // Select color when CEL view clicked
+        QObject::connect(this->celView, &CelView::colorIndexClicked, this->palWidget, &PaletteWidget::selectColor);
+        QObject::connect(this->celView, &CelView::colorIndexClicked, this->trn1Widget, &PaletteWidget::selectColor);
+        QObject::connect(this->celView, &CelView::colorIndexClicked, this->trn2Widget, &PaletteWidget::selectColor);
+
+        // Refresh palette widgets when frame
+        QObject::connect(this->celView, &CelView::frameRefreshed, this->palWidget, &PaletteWidget::refresh);
+
+        // Initialize palette widgets
+        this->palHits = new D1PalHits(this->cel);
+        this->palWidget->initialize(this->pal, this->celView, this->palHits);
+        this->trn1Widget->initialize(this->pal, this->trn1, this->celView, this->palHits);
+        this->trn2Widget->initialize(this->trn1->getResultingPalette(), this->trn2, this->celView, this->palHits);
+
+        this->celView->displayFrame();
+    }
+
+    // Look for all palettes in the same folder as the CEL/CL2 file
+    QDirIterator it(celFileInfo.absolutePath(), QStringList() << "*.pal", QDir::Files);
+    QString firstPaletteFound = QString();
+    while (it.hasNext()) {
+        QString sPath = it.next();
+
+        if (sPath != "1") {
+            QFileInfo palFileInfo(sPath);
+            QString path = palFileInfo.absoluteFilePath();
+            QString name = palFileInfo.fileName();
+            this->pals[path] = new D1Pal();
+
+            if (!this->pals[path]->load(path)) {
+                delete this->pals[path];
+                this->pals.remove(path);
+                QMessageBox::warning(this, "Warning", "Could not load PAL file.");
+                continue;
+            }
+
+            this->palWidget->addPath(path, name);
+
+            if (firstPaletteFound.isEmpty())
+                firstPaletteFound = path;
+        }
+    }
+    // Select the first palette found in the same folder as the CEL/CL2 if it exists
+    if (!firstPaletteFound.isEmpty())
+        this->palWidget->selectPath(firstPaletteFound);
+
+    // Adding the CelView to the main frame
+    if (this->celView != nullptr)
+        this->ui->mainFrame->layout()->addWidget(this->celView);
+    else
+        this->ui->mainFrame->layout()->addWidget(this->levelCelView);
+
+    // Adding the PalView to the pal frame
+    // this->ui->palFrame->layout()->addWidget( this->palView );
+
+    // update available menu entries
+    this->ui->menuEdit->setEnabled(true);
+    this->ui->menuPalette->setEnabled(true);
+    this->ui->actionExport->setEnabled(true);
+    this->ui->actionClose->setEnabled(true);
+
+    // Clear loading message from status bar
+    this->ui->statusBar->clearMessage();
+}
+
 void MainWindow::on_actionOpenAs_triggered()
 {
     this->openAsDialog->initialize(this->configuration);
@@ -492,20 +491,25 @@ void MainWindow::on_actionClose_triggered()
     delete this->cel;
 
     qDeleteAll(this->pals);
-    this->pals = QMap<QString, D1Pal *>();
+    this->pals.clear();
 
     qDeleteAll(this->trn1s);
-    this->trn1s = QMap<QString, D1Trn *>();
+    this->trn1s.clear();
 
     qDeleteAll(this->trn2s);
-    this->trn2s = QMap<QString, D1Trn *>();
+    this->trn2s.clear();
 
     delete this->min;
     delete this->til;
+    delete this->sol;
+    delete this->amp;
     delete this->palHits;
 
-    ui->menuPalette->setEnabled(false);
-    ui->actionExport->setEnabled(false);
+    // update available menu entries
+    this->ui->menuEdit->setEnabled(false);
+    this->ui->menuPalette->setEnabled(false);
+    this->ui->actionExport->setEnabled(false);
+    this->ui->actionClose->setEnabled(false);
 }
 
 void MainWindow::on_actionSettings_triggered()

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -79,7 +79,7 @@ private slots:
 
 private:
     Ui::MainWindow *ui;
-    QJsonObject *configuration = new QJsonObject;
+    QJsonObject *configuration = new QJsonObject();
 
     QUndoStack *undoStack;
     QAction *undoAction;


### PR DESCRIPTION
- use brackets when a constructor is called
- fix memory leak in mainwindow.cpp (delete openAsDialog in the destructor, sol and amp in close)
- disable close and edit menu option if nothing is opened
- call on_actionClose_triggered from the destructor of MainWindow to delete the opened objects
- reorder functions to match the order of the definitions (move paletteWidget_callback and the *PaletteCycle functions up)