### PR TITLE
cleanup D1CelBase

### DIFF
--- a/source/celview.cpp
+++ b/source/celview.cpp
@@ -135,9 +135,6 @@ void CelView::displayFrame()
 
 bool CelView::checkGroupNumber()
 {
-    if (this->cel->getGroupCount() == 1)
-        return true;
-
     QPair<quint16, quint16> groupFrameIndices = this->cel->getGroupFrameIndices(this->currentGroupIndex);
 
     return this->currentFrameIndex >= groupFrameIndices.first
@@ -161,19 +158,12 @@ void CelView::setGroupNumber()
 
 void CelView::playGroup()
 {
-    if (this->cel->getGroupCount() == 1) {
-        if (this->currentFrameIndex < this->cel->getFrameCount() - 1)
-            this->currentFrameIndex++;
-        else
-            this->currentFrameIndex = 0;
-    } else {
-        QPair<quint16, quint16> groupFrameIndices = this->cel->getGroupFrameIndices(this->currentGroupIndex);
+    QPair<quint16, quint16> groupFrameIndices = this->cel->getGroupFrameIndices(this->currentGroupIndex);
 
-        if (this->currentFrameIndex < groupFrameIndices.second)
-            this->currentFrameIndex++;
-        else
-            this->currentFrameIndex = groupFrameIndices.first;
-    }
+    if (this->currentFrameIndex < groupFrameIndices.second)
+        this->currentFrameIndex++;
+    else
+        this->currentFrameIndex = groupFrameIndices.first;
 
     MainWindow *mw = (MainWindow *)this->window();
     switch (this->ui->playComboBox->currentIndex()) {

--- a/source/d1celbase.cpp
+++ b/source/d1celbase.cpp
@@ -39,11 +39,6 @@ bool D1CelFrameBase::isClipped()
     return this->clipped;
 }
 
-D1CelBase::D1CelBase(D1Pal *pal)
-    : palette(pal)
-{
-}
-
 D1CelBase::~D1CelBase()
 {
     qDeleteAll(this->frames);
@@ -51,15 +46,16 @@ D1CelBase::~D1CelBase()
 
 bool D1CelBase::isFrameSizeConstant()
 {
-    if (this->frameCount == 0)
+    if (this->frames.isEmpty()) {
         return false;
+    }
 
-    quint16 frameWidth = this->getFrameWidth(0);
-    quint16 frameHeight = this->getFrameHeight(0);
+    quint16 frameWidth = this->frames[0]->getWidth();
+    quint16 frameHeight = this->frames[0]->getHeight();
 
-    for (unsigned int i = 1; i < this->frameCount; i++) {
-        if (this->getFrameWidth(i) != frameWidth
-            || this->getFrameHeight(i) != frameHeight)
+    for (unsigned int i = 1; i < this->frames.count(); i++) {
+        if (this->frames[i]->getWidth() != frameWidth
+            || this->frames[i]->getHeight() != frameHeight)
             return false;
     }
 
@@ -118,12 +114,12 @@ void D1CelBase::setPalette(D1Pal *pal)
 
 quint16 D1CelBase::getGroupCount()
 {
-    return this->groupCount;
+    return this->groupFrameIndices.count();
 }
 
 QPair<quint16, quint16> D1CelBase::getGroupFrameIndices(quint16 groupIndex)
 {
-    if (!this->groupFrameIndices.empty() && groupIndex < this->groupCount)
+    if (!this->groupFrameIndices.empty() && groupIndex < this->groupFrameIndices.count())
         return this->groupFrameIndices[groupIndex];
 
     return qMakePair(0, 0);
@@ -131,12 +127,12 @@ QPair<quint16, quint16> D1CelBase::getGroupFrameIndices(quint16 groupIndex)
 
 quint32 D1CelBase::getFrameCount()
 {
-    return this->frameCount;
+    return this->frames.count();
 }
 
 D1CelFrameBase *D1CelBase::getFrame(quint16 frameIndex)
 {
-    if (frameIndex >= this->frameCount)
+    if (frameIndex >= this->frames.count())
         return nullptr;
 
     return this->frames[frameIndex];
@@ -144,7 +140,7 @@ D1CelFrameBase *D1CelBase::getFrame(quint16 frameIndex)
 
 quint16 D1CelBase::getFrameWidth(quint16 frameIndex)
 {
-    if (frameIndex >= this->frameCount)
+    if (frameIndex >= this->frames.count())
         return 0;
 
     return this->frames[frameIndex]->getWidth();
@@ -152,7 +148,7 @@ quint16 D1CelBase::getFrameWidth(quint16 frameIndex)
 
 quint16 D1CelBase::getFrameHeight(quint16 frameIndex)
 {
-    if (frameIndex >= this->frameCount)
+    if (frameIndex >= this->frames.count())
         return 0;
 
     return this->frames[frameIndex]->getHeight();

--- a/source/d1celbase.h
+++ b/source/d1celbase.h
@@ -65,7 +65,6 @@ class D1CelBase : public QObject {
 
 public:
     D1CelBase() = default;
-    D1CelBase(D1Pal *pal);
     ~D1CelBase();
 
     virtual bool load(QString filePath, OpenAsParam *params = nullptr) = 0;
@@ -88,9 +87,6 @@ protected:
     D1CEL_TYPE type = D1CEL_TYPE::NONE;
     QString celFilePath;
     D1Pal *palette = nullptr;
-    quint16 groupCount = 1;
     QList<QPair<quint16, quint16>> groupFrameIndices;
-    quint32 frameCount = 0;
-    QList<QPair<quint32, quint32>> frameOffsets;
     QList<QPointer<D1CelFrameBase>> frames;
 };

--- a/source/d1celtileset.cpp
+++ b/source/d1celtileset.cpp
@@ -88,12 +88,12 @@ bool D1CelTileset::load(QString filePath, OpenAsParam *params)
     in >> fileSizeDword;
 
     this->groupFrameIndices.clear();
-    this->frameOffsets.clear();
 
     if (fileBuffer.size() != fileSizeDword)
         return false;
 
     // Going through all frames of the CEL
+    QList<QPair<quint32, quint32>> frameOffsets;
     for (unsigned i = 1; i <= firstDword; i++) {
         fileBuffer.seek(i * 4);
         quint32 celFrameStartOffset;
@@ -101,21 +101,19 @@ bool D1CelTileset::load(QString filePath, OpenAsParam *params)
         quint32 celFrameEndOffset;
         in >> celFrameEndOffset;
 
-        this->frameOffsets.append(qMakePair(celFrameStartOffset, celFrameEndOffset));
+        frameOffsets.append(qMakePair(celFrameStartOffset, celFrameEndOffset));
     }
 
-    if (this->frameOffsets.empty())
+    if (frameOffsets.empty())
         return false;
 
     // CEL FRAMES OFFSETS CALCULATION
-
-    this->frameCount = this->frameOffsets.size();
 
     // BUILDING {CEL FRAMES}
 
     qDeleteAll(this->frames);
     this->frames.clear();
-    for (const auto &offset : this->frameOffsets) {
+    for (const auto &offset : frameOffsets) {
         fileBuffer.seek(offset.first);
         QByteArray celFrameRawData = fileBuffer.read(offset.second - offset.first);
         D1CEL_FRAME_TYPE frameType = this->min->getFrameType(this->frames.count() + 1);


### PR DESCRIPTION
- get rid of the redundant fields
  I. groupCount == groupFrameIndices.count() if one group is always added
  II. frameCount == frames.count()
  III. frameOffsets are only used during load
- get rid of the unused constructor