### PR TITLE
make loading of tileset meta-data more robust

### DIFF
--- a/source/d1min.cpp
+++ b/source/d1min.cpp
@@ -55,11 +55,14 @@ bool D1Min::load(QString filePath, int subtileCount, std::map<unsigned, D1CEL_FR
     int minSubtileCount = fileSize / (subtileNumberOfCelFrames * 2);
     if (minSubtileCount != subtileCount) {
         qDebug() << "The size of sol-file does not align with min-file";
+        if (minSubtileCount > subtileCount) {
+            minSubtileCount = subtileCount; // skip unusable data
+        }
     }
 
     // prepare an empty list with zeros
     this->celFrameIndices.clear();
-    for (int i = 0; i < minSubtileCount; i++) {
+    for (int i = 0; i < subtileCount; i++) {
         QList<quint16> celFrameIndicesList;
         for (int j = 0; j < subtileNumberOfCelFrames; j++) {
             celFrameIndicesList.append(0);


### PR DESCRIPTION
- check if the load is failed (MainWindow::openFile)
- report error only if the file can not be read or the data is invalid
- do not change the entity till the success is guaranteed
- allow empty content
- guess width/height of min-data only if there is data
- skip unusable data
- add TILE_SIZE to use it instead of constants
+ fix createTile/createSubtile