### PR TITLE
Add create/clone buttons to tileset view

### DIFF
--- a/source/levelcelview.cpp
+++ b/source/levelcelview.cpp
@@ -346,6 +346,14 @@ void LevelCelView::createSubtile()
     this->displayFrame();
 }
 
+void LevelCelView::cloneSubtile()
+{
+    int cloneFrom = this->currentSubtileIndex;
+    this->createSubtile();
+    this->min->getCelFrameIndices(this->currentSubtileIndex) = this->min->getCelFrameIndices(cloneFrom);
+    this->displayFrame();
+}
+
 void LevelCelView::removeCurrentSubtile()
 {
     // check if the subtile is used
@@ -394,6 +402,14 @@ void LevelCelView::createTile()
     this->currentTileIndex = this->til->getTileCount() - 1;
     // update the view
     this->initialize(this->gfx, this->min, this->til, this->sol, this->amp);
+    this->displayFrame();
+}
+
+void LevelCelView::cloneTile()
+{
+    int cloneFrom = this->currentTileIndex;
+    this->createTile();
+    this->til->getSubtileIndices(this->currentTileIndex) = this->til->getSubtileIndices(cloneFrom);
     this->displayFrame();
 }
 
@@ -449,8 +465,7 @@ void LevelCelView::displayFrame()
         ->setPos(CEL_SCENE_SPACING, CEL_SCENE_SPACING);
 
     // Set current frame width and height
-    this->ui->celFrameWidthEdit->setText(QString::number(celFrame.width()));
-    this->ui->celFrameHeightEdit->setText(QString::number(celFrame.height()));
+    this->ui->celFrameHeightLabel->setText(QString::number(celFrame.width()) + " x " + QString::number(celFrame.height()) + " px");
 
     // Set current frame text
     this->ui->frameIndexEdit->setText(
@@ -464,8 +479,7 @@ void LevelCelView::displayFrame()
         ->setPos(minPosX, CEL_SCENE_SPACING);
 
     // Set current frame width and height
-    this->ui->minFrameWidthEdit->setText(QString::number(subtile.width()));
-    this->ui->minFrameHeightEdit->setText(QString::number(subtile.height()));
+    this->ui->minFrameHeightLabel->setText(QString::number(subtile.width()) + " x " + QString::number(subtile.height()) + " px");
 
     // Set current subtile text
     this->ui->subtileIndexEdit->setText(
@@ -479,8 +493,7 @@ void LevelCelView::displayFrame()
         ->setPos(tilPosX, CEL_SCENE_SPACING);
 
     // Set current frame width and height
-    this->ui->tilFrameWidthEdit->setText(QString::number(tile.width()));
-    this->ui->tilFrameHeightEdit->setText(QString::number(tile.height()));
+    this->ui->tilFrameHeightLabel->setText(QString::number(tile.width()) + " x " + QString::number(tile.height()) + " px");
 
     // Set current tile text
     this->ui->tileIndexEdit->setText(
@@ -831,4 +844,24 @@ void LevelCelView::dropEvent(QDropEvent *event)
     }
     // try to insert as frames
     ((MainWindow *)this->window())->openImageFiles(filePaths, false);
+}
+
+void LevelCelView::on_addTileButton_clicked()
+{
+    this->createTile();
+}
+
+void LevelCelView::on_cloneTileButton_clicked()
+{
+    this->cloneTile();
+}
+
+void LevelCelView::on_addSubTileButton_clicked()
+{
+    this->createSubtile();
+}
+
+void LevelCelView::on_cloneSubTileButton_clicked()
+{
+    this->cloneSubtile();
 }

--- a/source/levelcelview.h
+++ b/source/levelcelview.h
@@ -63,8 +63,10 @@ public:
     void replaceCurrentFrame(QString imagefilePath);
     void removeCurrentFrame();
     void createSubtile();
+    void cloneSubtile();
     void removeCurrentSubtile();
     void createTile();
+    void cloneTile();
     void removeCurrentTile();
 
     void displayFrame();
@@ -115,6 +117,14 @@ private slots:
 
     void dragEnterEvent(QDragEnterEvent *event);
     void dropEvent(QDropEvent *event);
+
+    void on_addTileButton_clicked();
+
+    void on_cloneTileButton_clicked();
+
+    void on_addSubTileButton_clicked();
+
+    void on_cloneSubTileButton_clicked();
 
 private:
     Ui::LevelCelView *ui;

--- a/source/levelcelview.ui
+++ b/source/levelcelview.ui
@@ -84,48 +84,90 @@
       </item>
       <item>
        <layout class="QGridLayout" name="levelCelControlsGridLayout">
-        <item row="1" column="1">
-         <widget class="QPushButton" name="zoomOutButton">
+        <item row="1" column="0">
+         <widget class="QLabel" name="tilLabel">
           <property name="minimumSize">
            <size>
-            <width>24</width>
+            <width>48</width>
             <height>0</height>
            </size>
           </property>
-          <property name="maximumSize">
-           <size>
-            <width>30</width>
-            <height>16777215</height>
-           </size>
-          </property>
           <property name="text">
-           <string>-</string>
+           <string>Tiles :</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="9">
-         <widget class="QLabel" name="slashLabel_3">
-          <property name="minimumSize">
-           <size>
-            <width>8</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>8</width>
-            <height>16777215</height>
-           </size>
-          </property>
+        <item row="1" column="13">
+         <widget class="QLabel" name="tilFrameHeightLabel">
           <property name="text">
-           <string>-</string>
+           <string>px</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
-        <item row="1" column="7" colspan="2">
+        <item row="2" column="9">
+         <widget class="QPushButton" name="nextSubtileButton">
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Next group</string>
+          </property>
+          <property name="text">
+           <string>&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="12">
+         <widget class="QPushButton" name="cloneSubTileButton">
+          <property name="maximumSize">
+           <size>
+            <width>24</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="icon">
+           <iconset theme="edit-copy"/>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="4">
+         <widget class="QPushButton" name="firstTileButton">
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>First group</string>
+          </property>
+          <property name="text">
+           <string>|&lt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="5" colspan="2">
          <widget class="QPushButton" name="stopButton">
           <property name="minimumSize">
            <size>
@@ -144,8 +186,8 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="10" colspan="2">
-         <widget class="QPushButton" name="playButton">
+        <item row="0" column="0">
+         <widget class="QLabel" name="zoomLabel">
           <property name="minimumSize">
            <size>
             <width>0</width>
@@ -159,109 +201,30 @@
            </size>
           </property>
           <property name="text">
-           <string>Play</string>
+           <string>Zoom:</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="12">
-         <widget class="QLineEdit" name="playDelayEdit">
+        <item row="0" column="2">
+         <widget class="QLineEdit" name="zoomEdit">
           <property name="minimumSize">
            <size>
-            <width>48</width>
+            <width>24</width>
             <height>0</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>48</width>
+            <width>24</width>
             <height>16777215</height>
            </size>
-          </property>
-          <property name="toolTip">
-           <string>Current playback delay</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="13">
-         <widget class="QLabel" name="playDelayLabel">
-          <property name="text">
-           <string>ms</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="14" colspan="2">
-         <widget class="QComboBox" name="playComboBox">
-          <item>
-           <property name="text">
-            <string>Caves</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Nest</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Crypt</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="3" column="9">
-         <widget class="QLabel" name="minSlashLabel">
-          <property name="minimumSize">
-           <size>
-            <width>8</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>8</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>/</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>
           </property>
          </widget>
         </item>
-        <item row="2" column="8">
-         <widget class="QLineEdit" name="tileIndexEdit">
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Current group</string>
-          </property>
-          <property name="text">
-           <string>0</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="7">
+        <item row="3" column="5">
          <widget class="QPushButton" name="previousFrameButton">
           <property name="minimumSize">
            <size>
@@ -283,30 +246,8 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="9">
-         <widget class="QLabel" name="tilSlashLabel">
-          <property name="minimumSize">
-           <size>
-            <width>8</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>8</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>/</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-         </widget>
-        </item>
         <item row="3" column="0">
-         <widget class="QLabel" name="minLabel">
+         <widget class="QLabel" name="framesLabel">
           <property name="minimumSize">
            <size>
             <width>48</width>
@@ -314,138 +255,59 @@
            </size>
           </property>
           <property name="text">
-           <string>Sub-tiles :</string>
+           <string>Frames :</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="14">
-         <widget class="QLineEdit" name="tilFrameWidthEdit">
-          <property name="minimumSize">
-           <size>
-            <width>32</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>32</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Current frame width</string>
+        <item row="0" column="11">
+         <widget class="QLabel" name="playDelayLabel">
+          <property name="text">
+           <string>ms</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="readOnly">
-           <bool>true</bool>
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
-        <item row="4" column="12">
-         <widget class="QPushButton" name="lastFrameButton">
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>40</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Last frame</string>
-          </property>
-          <property name="text">
-           <string>&gt;|</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="12">
-         <widget class="QPushButton" name="lastTileButton">
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>40</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Last group</string>
-          </property>
-          <property name="text">
-           <string>&gt;|</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="13">
-         <spacer name="minRightHorizontalSpacer">
+        <item row="1" column="3">
+         <spacer name="horizontalSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>77</width>
+            <width>40</width>
             <height>20</height>
            </size>
           </property>
          </spacer>
         </item>
-        <item row="3" column="16">
-         <widget class="QLineEdit" name="minFrameHeightEdit">
+        <item row="3" column="6">
+         <widget class="QLineEdit" name="frameIndexEdit">
           <property name="minimumSize">
            <size>
-            <width>32</width>
+            <width>50</width>
             <height>0</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>32</width>
+            <width>50</width>
             <height>16777215</height>
            </size>
           </property>
           <property name="toolTip">
-           <string>Current frame height</string>
+           <string>Current frame</string>
+          </property>
+          <property name="text">
+           <string>0</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="readOnly">
-           <bool>true</bool>
+           <set>Qt::AlignCenter</set>
           </property>
          </widget>
         </item>
-        <item row="3" column="1" colspan="4">
-         <spacer name="minLeftHorizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>77</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="4" column="15">
-         <widget class="QLabel" name="celFrameWidthLabel">
-          <property name="text">
-           <string>px *</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="10">
+        <item row="2" column="8">
          <widget class="QLineEdit" name="subtileNumberEdit">
           <property name="minimumSize">
            <size>
@@ -476,37 +338,8 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="7">
-         <widget class="QPushButton" name="previousSubtileButton">
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>40</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Previous group</string>
-          </property>
-          <property name="text">
-           <string>&lt;</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="17">
-         <widget class="QLabel" name="celFrameHeightLabel">
-          <property name="text">
-           <string>px</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="2">
-         <widget class="QLineEdit" name="zoomEdit">
+        <item row="0" column="1">
+         <widget class="QPushButton" name="zoomOutButton">
           <property name="minimumSize">
            <size>
             <width>24</width>
@@ -515,64 +348,33 @@
           </property>
           <property name="maximumSize">
            <size>
+            <width>30</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>-</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="12">
+         <widget class="QPushButton" name="cloneTileButton">
+          <property name="maximumSize">
+           <size>
             <width>24</width>
             <height>16777215</height>
            </size>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="11">
-         <widget class="QPushButton" name="nextTileButton">
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>40</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Next group</string>
-          </property>
           <property name="text">
-           <string>&gt;</string>
+           <string/>
           </property>
-         </widget>
-        </item>
-        <item row="3" column="8">
-         <widget class="QLineEdit" name="subtileIndexEdit">
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Current group</string>
-          </property>
-          <property name="text">
-           <string>0</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
+          <property name="icon">
+           <iconset theme="edit-copy"/>
           </property>
          </widget>
         </item>
         <item row="2" column="0">
-         <widget class="QLabel" name="tilLabel">
+         <widget class="QLabel" name="minLabel">
           <property name="minimumSize">
            <size>
             <width>48</width>
@@ -580,129 +382,21 @@
            </size>
           </property>
           <property name="text">
-           <string>Tiles :</string>
+           <string>Sub-tiles :</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="11">
-         <widget class="QPushButton" name="nextFrameButton">
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>40</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Next frame</string>
-          </property>
-          <property name="text">
-           <string>&gt;</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="6">
-         <widget class="QPushButton" name="firstTileButton">
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>40</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>First group</string>
-          </property>
-          <property name="text">
-           <string>|&lt;</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="framesLabel">
-          <property name="minimumSize">
-           <size>
-            <width>48</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Frames :</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="15">
-         <widget class="QLabel" name="tilFrameWidthLabel">
-          <property name="text">
-           <string>px *</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="17">
-         <widget class="QLabel" name="minFrameHeightLabel">
+        <item row="3" column="13">
+         <widget class="QLabel" name="celFrameHeightLabel">
           <property name="text">
            <string>px</string>
           </property>
-         </widget>
-        </item>
-        <item row="4" column="8">
-         <widget class="QLineEdit" name="frameIndexEdit">
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Current frame</string>
-          </property>
-          <property name="text">
-           <string>0</string>
-          </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
-        <item row="4" column="9">
-         <widget class="QLabel" name="slashLabel">
-          <property name="minimumSize">
-           <size>
-            <width>8</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>8</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>/</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="15" colspan="3">
+        <item row="0" column="12">
          <spacer name="horizontalSpacer_2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
@@ -715,156 +409,29 @@
           </property>
          </spacer>
         </item>
-        <item row="3" column="12">
-         <widget class="QPushButton" name="lastSubtileButton">
+        <item row="0" column="10">
+         <widget class="QLineEdit" name="playDelayEdit">
           <property name="minimumSize">
            <size>
-            <width>40</width>
+            <width>48</width>
             <height>0</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>40</width>
+            <width>48</width>
             <height>16777215</height>
            </size>
           </property>
           <property name="toolTip">
-           <string>Last group</string>
-          </property>
-          <property name="text">
-           <string>&gt;|</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="15">
-         <widget class="QLabel" name="minFrameWidthLabel">
-          <property name="text">
-           <string>px *</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="10">
-         <widget class="QLineEdit" name="tileNumberEdit">
-          <property name="minimumSize">
-           <size>
-            <width>50</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>50</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Number of groups</string>
-          </property>
-          <property name="autoFillBackground">
-           <bool>false</bool>
-          </property>
-          <property name="text">
-           <string>0</string>
+           <string>Current playback delay</string>
           </property>
           <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-          <property name="readOnly">
-           <bool>true</bool>
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
-        <item row="4" column="16">
-         <widget class="QLineEdit" name="celFrameHeightEdit">
-          <property name="minimumSize">
-           <size>
-            <width>32</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>32</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Current frame height</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="readOnly">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="17">
-         <widget class="QLabel" name="tilFrameHeightLabel">
-          <property name="text">
-           <string>px</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="6">
-         <widget class="QPushButton" name="firstFrameButton">
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>40</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>First frame</string>
-          </property>
-          <property name="text">
-           <string>|&lt;</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="11">
-         <widget class="QPushButton" name="nextSubtileButton">
-          <property name="minimumSize">
-           <size>
-            <width>40</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>40</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Next group</string>
-          </property>
-          <property name="text">
-           <string>&gt;</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="13">
-         <spacer name="tilRightHorizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>77</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="4" column="10">
+        <item row="3" column="8">
          <widget class="QLineEdit" name="frameNumberEdit">
           <property name="minimumSize">
            <size>
@@ -895,58 +462,140 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="4">
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="2" column="16">
-         <widget class="QLineEdit" name="tilFrameHeightEdit">
+        <item row="3" column="10">
+         <widget class="QPushButton" name="lastFrameButton">
           <property name="minimumSize">
            <size>
-            <width>32</width>
+            <width>40</width>
             <height>0</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>32</width>
+            <width>40</width>
             <height>16777215</height>
            </size>
           </property>
           <property name="toolTip">
-           <string>Current frame height</string>
+           <string>Last frame</string>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="readOnly">
-           <bool>true</bool>
+          <property name="text">
+           <string>&gt;|</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1" colspan="4">
-         <spacer name="tilLeftHorizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
+        <item row="1" column="11">
+         <widget class="QPushButton" name="addTileButton">
+          <property name="maximumSize">
            <size>
-            <width>77</width>
-            <height>20</height>
+            <width>24</width>
+            <height>16777215</height>
            </size>
           </property>
-         </spacer>
+          <property name="text">
+           <string>+</string>
+          </property>
+         </widget>
         </item>
-        <item row="3" column="6">
+        <item row="2" column="7">
+         <widget class="QLabel" name="minSlashLabel">
+          <property name="minimumSize">
+           <size>
+            <width>8</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>8</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>/</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="3">
+         <widget class="QPushButton" name="zoomInButton">
+          <property name="minimumSize">
+           <size>
+            <width>30</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>24</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>+</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="8" colspan="2">
+         <widget class="QPushButton" name="playButton">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Play</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="6">
+         <widget class="QLineEdit" name="subtileIndexEdit">
+          <property name="minimumSize">
+           <size>
+            <width>50</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>50</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Current group</string>
+          </property>
+          <property name="text">
+           <string>0</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="11">
+         <widget class="QPushButton" name="addSubTileButton">
+          <property name="maximumSize">
+           <size>
+            <width>24</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>+</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="4">
          <widget class="QPushButton" name="firstSubtileButton">
           <property name="minimumSize">
            <size>
@@ -968,53 +617,8 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="1" colspan="4">
-         <spacer name="framesLeftHorizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="zoomLabel">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>16777215</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>Zoom:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="13">
-         <spacer name="framesRightHorizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="2" column="7">
-         <widget class="QPushButton" name="previousTileButton">
+        <item row="2" column="5">
+         <widget class="QPushButton" name="previousSubtileButton">
           <property name="minimumSize">
            <size>
             <width>40</width>
@@ -1035,72 +639,286 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="14">
-         <widget class="QLineEdit" name="celFrameWidthEdit">
-          <property name="minimumSize">
-           <size>
-            <width>32</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>32</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Current frame width</string>
+        <item row="2" column="13">
+         <widget class="QLabel" name="minFrameHeightLabel">
+          <property name="text">
+           <string>px</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
-          <property name="readOnly">
-           <bool>true</bool>
-          </property>
          </widget>
         </item>
-        <item row="3" column="14">
-         <widget class="QLineEdit" name="minFrameWidthEdit">
+        <item row="3" column="7">
+         <widget class="QLabel" name="slashLabel">
           <property name="minimumSize">
            <size>
-            <width>32</width>
+            <width>8</width>
             <height>0</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>32</width>
-            <height>16777215</height>
-           </size>
-          </property>
-          <property name="toolTip">
-           <string>Current frame width</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-          <property name="readOnly">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="3">
-         <widget class="QPushButton" name="zoomInButton">
-          <property name="minimumSize">
-           <size>
-            <width>30</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="maximumSize">
-           <size>
-            <width>24</width>
+            <width>8</width>
             <height>16777215</height>
            </size>
           </property>
           <property name="text">
-           <string>+</string>
+           <string>/</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="7">
+         <widget class="QLabel" name="tilSlashLabel">
+          <property name="minimumSize">
+           <size>
+            <width>8</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>8</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>/</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="6">
+         <widget class="QLineEdit" name="tileIndexEdit">
+          <property name="minimumSize">
+           <size>
+            <width>50</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>50</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Current group</string>
+          </property>
+          <property name="text">
+           <string>0</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="7">
+         <widget class="QLabel" name="slashLabel_3">
+          <property name="minimumSize">
+           <size>
+            <width>8</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>8</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>-</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="4">
+         <widget class="QPushButton" name="firstFrameButton">
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>First frame</string>
+          </property>
+          <property name="text">
+           <string>|&lt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="8">
+         <widget class="QLineEdit" name="tileNumberEdit">
+          <property name="minimumSize">
+           <size>
+            <width>50</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>50</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Number of groups</string>
+          </property>
+          <property name="autoFillBackground">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>0</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="10">
+         <widget class="QPushButton" name="lastSubtileButton">
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Last group</string>
+          </property>
+          <property name="text">
+           <string>&gt;|</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="13">
+         <widget class="QComboBox" name="playComboBox">
+          <item>
+           <property name="text">
+            <string>Caves</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Nest</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Crypt</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="1" column="10">
+         <widget class="QPushButton" name="lastTileButton">
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Last group</string>
+          </property>
+          <property name="text">
+           <string>&gt;|</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="9">
+         <widget class="QPushButton" name="nextTileButton">
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Next group</string>
+          </property>
+          <property name="text">
+           <string>&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="9">
+         <widget class="QPushButton" name="nextFrameButton">
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Next frame</string>
+          </property>
+          <property name="text">
+           <string>&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="5">
+         <widget class="QPushButton" name="previousTileButton">
+          <property name="minimumSize">
+           <size>
+            <width>40</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="toolTip">
+           <string>Previous group</string>
+          </property>
+          <property name="text">
+           <string>&lt;</string>
           </property>
          </widget>
         </item>

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -852,6 +852,12 @@ void MainWindow::on_actionCreate_Subtile_triggered()
     this->updateView();
 }
 
+void MainWindow::on_actionClone_Subtile_triggered()
+{
+    this->levelCelView->cloneSubtile();
+    this->updateView();
+}
+
 void MainWindow::on_actionDel_Subtile_triggered()
 {
     this->levelCelView->removeCurrentSubtile();
@@ -861,6 +867,12 @@ void MainWindow::on_actionDel_Subtile_triggered()
 void MainWindow::on_actionCreate_Tile_triggered()
 {
     this->levelCelView->createTile();
+    this->updateView();
+}
+
+void MainWindow::on_actionClone_Tile_triggered()
+{
+    this->levelCelView->cloneTile();
     this->updateView();
 }
 

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -63,8 +63,10 @@ public slots:
     void on_actionReplace_Frame_triggered();
     void on_actionDel_Frame_triggered();
     void on_actionCreate_Subtile_triggered();
+    void on_actionClone_Subtile_triggered();
     void on_actionDel_Subtile_triggered();
     void on_actionCreate_Tile_triggered();
+    void on_actionClone_Tile_triggered();
     void on_actionDel_Tile_triggered();
 
 private slots:

--- a/source/mainwindow.ui
+++ b/source/mainwindow.ui
@@ -128,7 +128,7 @@
      <x>0</x>
      <y>0</y>
      <width>1200</width>
-     <height>21</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -188,9 +188,11 @@
     <addaction name="actionDel_Frame"/>
     <addaction name="separator"/>
     <addaction name="actionCreate_Subtile"/>
+    <addaction name="actionClone_Subtile"/>
     <addaction name="actionDel_Subtile"/>
     <addaction name="separator"/>
     <addaction name="actionCreate_Tile"/>
+    <addaction name="actionClone_Tile"/>
     <addaction name="actionDel_Tile"/>
    </widget>
    <addaction name="menuFile"/>
@@ -420,6 +422,22 @@
   <action name="actionNew_Translation_1">
    <property name="text">
     <string>New unique translation</string>
+   </property>
+  </action>
+  <action name="actionClone_Subtile">
+   <property name="text">
+    <string>Clone Subtile</string>
+   </property>
+   <property name="toolTip">
+    <string>Clone current subtile</string>
+   </property>
+  </action>
+  <action name="actionClone_Tile">
+   <property name="text">
+    <string>Clone Tile</string>
+   </property>
+   <property name="toolTip">
+    <string>Clone current tile</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
closes #97

Based on some user feedback I have added buttons for easier tile editing.

![image](https://user-images.githubusercontent.com/204594/211107948-c7923fb6-c839-4e6e-9c03-e93205ca2363.png)