### PR TITLE
Align level tile naming convention with outside world

### DIFF
--- a/source/exportdialog.ui
+++ b/source/exportdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>797</width>
-    <height>368</height>
+    <height>369</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -61,6 +61,12 @@
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
        </spacer>
       </item>
       <item row="1" column="0">
@@ -88,6 +94,12 @@
        <spacer name="horizontalSpacer2">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
         </property>
        </spacer>
       </item>
@@ -128,17 +140,17 @@
         </item>
         <item>
          <property name="text">
-          <string>Subtile</string>
+          <string>Tile</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Flat Tile</string>
+          <string>Flat MegaTile</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>2.5D Tile</string>
+          <string>2.5D MegaTile</string>
          </property>
         </item>
        </widget>
@@ -147,6 +159,12 @@
        <spacer name="horizontalSpacer3">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
         </property>
        </spacer>
       </item>
@@ -192,6 +210,12 @@
        <spacer name="horizontalSpacer4">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
         </property>
        </spacer>
       </item>
@@ -312,6 +336,12 @@
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
        </spacer>
       </item>
      </layout>
@@ -340,6 +370,12 @@
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
        </spacer>
       </item>
       <item>
@@ -363,5 +399,4 @@
  </widget>
  <resources/>
  <connections/>
- <buttongroups/>
 </ui>

--- a/source/levelcelview.ui
+++ b/source/levelcelview.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>874</width>
-    <height>521</height>
+    <height>523</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -450,7 +450,7 @@
            </size>
           </property>
           <property name="text">
-           <string>Tiles:</string>
+           <string>MegaTiles:</string>
           </property>
          </widget>
         </item>
@@ -979,7 +979,7 @@
            </size>
           </property>
           <property name="text">
-           <string>Sub-tiles:</string>
+           <string>Tiles:</string>
           </property>
          </widget>
         </item>

--- a/source/mainwindow.ui
+++ b/source/mainwindow.ui
@@ -325,7 +325,7 @@
   </action>
   <action name="actionCleanupFrames_Tileset">
    <property name="text">
-    <string>Cleanup frames</string>
+    <string>Cleanup Frames</string>
    </property>
    <property name="toolTip">
     <string>Delete frames not used by any subtile</string>
@@ -333,7 +333,7 @@
   </action>
   <action name="actionCleanupSubtiles_Tileset">
    <property name="text">
-    <string>Cleanup Subtiles</string>
+    <string>Cleanup Tiles</string>
    </property>
    <property name="toolTip">
     <string>Delete subtiles not used by any tile</string>
@@ -357,7 +357,7 @@
   </action>
   <action name="actionSortSubtiles_Tileset">
    <property name="text">
-    <string>Sort Subtiles</string>
+    <string>Sort Tiles</string>
    </property>
    <property name="toolTip">
     <string>Sort the subtiles based on the tiles</string>


### PR DESCRIPTION
As discussed on Discord the naming convention is a bit off for tilesets.
https://discord.com/channels/518540764754608128/518541192993046562/1153764742670852147

Changing it from:
Tile
Sub-tile
Frame

To:
MegaTile
Tile
Frame

This aligns with the engine and various community other docs.