### PR TITLE
Fix: Incorrect directory path if tool is installed by package

### DIFF
--- a/source/config.cpp
+++ b/source/config.cpp
@@ -11,6 +11,13 @@
 static QJsonObject theConfig;
 QString Config::jsonFilePath;
 
+/**
+ * @brief Loads current configuration from the config .json file
+ *
+ *  This function loads current configuration from the config .json file.
+ *  It inserts specific values mapping them to keys, and creates path for the
+ *  config if user has deleted it, or runs app for the first time.
+ */
 void Config::loadConfiguration()
 {
     // create directories on the path if they do not exist
@@ -51,6 +58,9 @@ void Config::loadConfiguration()
     }
 }
 
+/**
+ * @brief Stores current configuration in the config .json file
+ */
 void Config::storeConfiguration()
 {
     QFile saveJson(jsonFilePath);
@@ -60,6 +70,17 @@ void Config::storeConfiguration()
     saveJson.close();
 }
 
+/**
+ * @brief Creates directories on certain path
+ *
+ * This function creates directories on certain path. Path location depends on
+ * if user is working on Windows or Mac/Linux.
+ *
+ * If the user works on Windows, it will save it under AppData/.config/[...].
+ * On any other OS it will save it under /home/user/.config/diasurgical/[...]
+ *
+ * @return Returns true if path has been created or already existed - false otherwise
+ */
 bool Config::createDirectoriesOnPath()
 {
     jsonFilePath = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
@@ -67,11 +88,26 @@ bool Config::createDirectoriesOnPath()
     return QDir().mkpath(jsonFilePath);
 }
 
+/**
+ * @brief Retrieves value from .json config file
+ *
+ * This function retrieves value from .json config file by the value
+ * specified by name parameter.
+ *
+ * @return Returns QJsonValue containing value of the parameter specified
+ * by "name" key, otherwise if not found - returns QJsonValue::Undefined
+ */
 QJsonValue Config::value(const QString &name)
 {
     return theConfig.value(name);
 }
 
+/**
+ * @brief Inserts value in .json config file
+ *
+ * This function inserts value into .json config file, mapping it with
+ * the key specified in parameters.
+ */
 void Config::insert(const QString &key, const QJsonValue &value)
 {
     theConfig.insert(key, value);

--- a/source/config.cpp
+++ b/source/config.cpp
@@ -1,15 +1,27 @@
 #include "config.h"
 
 #include <QCoreApplication>
+#include <QDebug>
+#include <QDir>
 #include <QFile>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QStandardPaths>
 
 static QJsonObject theConfig;
+QString Config::jsonFilePath;
 
 void Config::loadConfiguration()
 {
-    QString jsonFilePath = QCoreApplication::applicationDirPath() + "/D1GraphicsTool.config.json";
+    // create directories on the path if they do not exist
+    if (!Config::createDirectoriesOnPath()) {
+        qDebug() << "Couldn't resolve path for the config file. Configuration file won't be loaded.";
+        return;
+    }
+
+    // add filename to the absolute path
+    jsonFilePath += "/D1GraphicsTool.config.json";
+
     bool configurationModified = false;
 
     // If configuration file exists load it otherwise create it
@@ -41,13 +53,18 @@ void Config::loadConfiguration()
 
 void Config::storeConfiguration()
 {
-    QString jsonFilePath = QCoreApplication::applicationDirPath() + "/D1GraphicsTool.config.json";
-
     QFile saveJson(jsonFilePath);
     saveJson.open(QIODevice::WriteOnly);
     QJsonDocument saveDoc(theConfig);
     saveJson.write(saveDoc.toJson());
     saveJson.close();
+}
+
+bool Config::createDirectoriesOnPath()
+{
+    jsonFilePath = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+
+    return QDir().mkpath(jsonFilePath);
 }
 
 QJsonValue Config::value(const QString &name)

--- a/source/config.h
+++ b/source/config.h
@@ -8,4 +8,9 @@ public:
     static void storeConfiguration();
     static QJsonValue value(const QString &name);
     static void insert(const QString &key, const QJsonValue &value);
+
+private:
+    static bool createDirectoriesOnPath();
+
+    static QString jsonFilePath;
 };


### PR DESCRIPTION
Currently, if we install d1-graphics-tool with a .deb package, it will try to resolve the path to save a .json file to /usr/bin, since currently we save the configuration file wherever the binary is. User doesn't have an access to write to /usr/bin/ directly and this ends up with a problem in reading/writing to a config, resetting the config everytime app is being used.

This patch changes it, and leaves the configuration for the file to be saved in:
- Windows: AppData/.config/diasurgical/d1-graphics-tool/ directory path
- Otherwise: /home/user/.config/diasurgical/d1-graphics-tool/ directory path

Also added missing documentation for config.cpp.
