### PR TITLE
Fix: Don't reset frame count upon click if there's only 1 frame group

### DIFF
--- a/source/celview.cpp
+++ b/source/celview.cpp
@@ -388,11 +388,19 @@ void CelView::on_frameIndexEdit_returnPressed()
 
 void CelView::on_firstGroupButton_clicked()
 {
+    // don't do anything if there's only one group
+    if (this->gfx->getGroupCount() == 1)
+        return;
+
     this->on_firstFrameButton_clicked();
 }
 
 void CelView::on_previousGroupButton_clicked()
 {
+    // don't do anything if there's only one group
+    if (this->gfx->getGroupCount() == 1)
+        return;
+
     if (this->currentGroupIndex >= 1)
         this->currentGroupIndex--;
     else
@@ -415,6 +423,10 @@ void CelView::on_groupIndexEdit_returnPressed()
 
 void CelView::on_nextGroupButton_clicked()
 {
+    // don't do anything if there's only one group
+    if (this->gfx->getGroupCount() == 1)
+        return;
+
     if (this->currentGroupIndex < (this->gfx->getGroupCount() - 1))
         this->currentGroupIndex++;
     else
@@ -426,6 +438,10 @@ void CelView::on_nextGroupButton_clicked()
 
 void CelView::on_lastGroupButton_clicked()
 {
+    // don't do anything if there's only one group
+    if (this->gfx->getGroupCount() == 1)
+        return;
+
     this->currentGroupIndex = std::max(0, this->gfx->getGroupCount() - 1);
     this->currentFrameIndex = this->gfx->getGroupFrameIndices(this->currentGroupIndex).first;
     this->displayFrame();


### PR DESCRIPTION
This patch fixes a behavior when user clicks one of these buttons:
- previous frame group button
- next frame group button
- last frame group button
- first frame group button

And there is only one frame group available. Currently if someone presses those buttons frame count will be reseted, this patch fixes it by basically returning from function immediately if there's only 1 frame group available.

To be exact, this patch fixes this behavior:

https://github.com/diasurgical/d1-graphics-tool/assets/59984746/f5c77d49-5a19-424a-9503-ae699da02e1c