### PR TITLE
Cleanup: Align rest of UI with Tile/Megatile naming

### DIFF
--- a/source/levelcelview.cpp
+++ b/source/levelcelview.cpp
@@ -27,8 +27,8 @@ LevelCelView::LevelCelView(QWidget *parent)
     this->ui->playDelayEdit->setText(QString::number(this->currentPlayDelay));
     this->ui->stopButton->setEnabled(false);
     this->playTimer.connect(&this->playTimer, SIGNAL(timeout()), this, SLOT(playGroup()));
-    this->ui->tilesTabs->addTab(this->tabTileWidget, "Tile properties");
-    this->ui->tilesTabs->addTab(this->tabSubTileWidget, "Subtile properties");
+    this->ui->tilesTabs->addTab(this->tabTileWidget, "MegaTile properties");
+    this->ui->tilesTabs->addTab(this->tabSubTileWidget, "Tile properties");
     this->ui->tilesTabs->addTab(this->tabFrameWidget, "Frame properties");
 
     // If a pixel of the frame, subtile or tile was clicked get pixel color index and notify the palette widgets
@@ -74,9 +74,9 @@ void LevelCelView::update()
     if (this->mode == TILESET_MODE::FREE)
         ui->modeLabel->setText("");
     else if (this->mode == TILESET_MODE::SUBTILE)
-        ui->modeLabel->setText("Subtile mode");
-    else if (this->mode == TILESET_MODE::TILE)
         ui->modeLabel->setText("Tile mode");
+    else if (this->mode == TILESET_MODE::TILE)
+        ui->modeLabel->setText("MegaTile mode");
 
     ui->frameNumberEdit->setText(
         QString::number(this->gfx->getFrameCount()));
@@ -692,7 +692,7 @@ void LevelCelView::removeCurrentFrame()
 
     if (!frameUsers.isEmpty()) {
         QMessageBox::StandardButton reply;
-        reply = QMessageBox::question(nullptr, "Confirmation", "The frame is used by Subtile " + QString::number(frameUsers.first() + 1) + " (and maybe others). Are you sure you want to proceed?", QMessageBox::Yes | QMessageBox::No);
+        reply = QMessageBox::question(nullptr, "Confirmation", "The frame is used by Tile " + QString::number(frameUsers.first() + 1) + " (and maybe others). Are you sure you want to proceed?", QMessageBox::Yes | QMessageBox::No);
         if (reply != QMessageBox::Yes) {
             return;
         }
@@ -778,7 +778,7 @@ void LevelCelView::removeCurrentSubtile()
     this->collectSubtileUsers(this->currentSubtileIndex, subtileUsers);
 
     if (!subtileUsers.isEmpty()) {
-        QMessageBox::critical(nullptr, "Error", "The subtile is used by Tile " + QString::number(subtileUsers.first() + 1) + " (and maybe others).");
+        QMessageBox::critical(nullptr, "Error", "The tile is used by MegaTile " + QString::number(subtileUsers.first() + 1) + " (and maybe others).");
         return;
     }
     // remove the current subtile
@@ -888,7 +888,7 @@ void LevelCelView::reportUsage()
         if (frameUsers.isEmpty()) {
             frameUses += " is not used by any subtile.";
         } else {
-            frameUses += " is used by subtile ";
+            frameUses += " is used by tile ";
             for (int user : frameUsers) {
                 frameUses += QString::number(user + 1) + ", ";
             }
@@ -903,11 +903,11 @@ void LevelCelView::reportUsage()
         QList<int> subtileUsers;
         this->collectSubtileUsers(this->currentSubtileIndex, subtileUsers);
 
-        subtileUses = "Subtile " + QString::number(this->currentSubtileIndex + 1);
+        subtileUses = "Tile " + QString::number(this->currentSubtileIndex + 1);
         if (subtileUsers.isEmpty()) {
-            subtileUses += " is not used by any tile.";
+            subtileUses += " is not used by any MegaTile.";
         } else {
-            subtileUses += " is used by tile ";
+            subtileUses += " is used by MegaTile ";
             for (int user : subtileUsers) {
                 subtileUses += QString::number(user + 1) + ", ";
             }
@@ -1481,7 +1481,7 @@ void LevelCelView::ShowContextMenu(const QPoint &pos)
 
     contextMenu.addMenu(&frameMenu);
 
-    QMenu subtileMenu(tr("Subtile"), this);
+    QMenu subtileMenu(tr("Tile"), this);
     subtileMenu.setToolTipsVisible(true);
 
     QAction action4("Create", this);
@@ -1517,7 +1517,7 @@ void LevelCelView::ShowContextMenu(const QPoint &pos)
 
     contextMenu.addMenu(&subtileMenu);
 
-    QMenu tileMenu(tr("Tile"), this);
+    QMenu tileMenu(tr("MegaTile"), this);
     tileMenu.setToolTipsVisible(true);
 
     QAction action9("Create", this);

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -70,22 +70,22 @@ MainWindow::MainWindow()
 
     // Initialize 'Subtile' submenu of 'Edit'
     this->subtileMenu.setToolTipsVisible(true);
-    this->subtileMenu.addAction("Create", this, SLOT(on_actionCreate_Subtile_triggered()))->setToolTip("Create a new subtile");
-    this->subtileMenu.addAction("Insert", this, SLOT(on_actionInsert_Subtile_triggered()))->setToolTip("Add new subtiles before the current one");
-    this->subtileMenu.addAction("Add", this, SLOT(on_actionAdd_Subtile_triggered()))->setToolTip("Add new subtiles at the end");
-    this->subtileMenu.addAction("Clone", this, SLOT(on_actionClone_Subtile_triggered()))->setToolTip("Add new subtiles at the end based on the current one");
-    this->subtileMenu.addAction("Replace", this, SLOT(on_actionReplace_Subtile_triggered()))->setToolTip("Replace the current subtile");
-    this->subtileMenu.addAction("Delete", this, SLOT(on_actionDel_Subtile_triggered()))->setToolTip("Delete the current subtile");
+    this->subtileMenu.addAction("Create", this, SLOT(on_actionCreate_Subtile_triggered()))->setToolTip("Create a new tile");
+    this->subtileMenu.addAction("Insert", this, SLOT(on_actionInsert_Subtile_triggered()))->setToolTip("Add new tiles before the current one");
+    this->subtileMenu.addAction("Add", this, SLOT(on_actionAdd_Subtile_triggered()))->setToolTip("Add new tiles at the end");
+    this->subtileMenu.addAction("Clone", this, SLOT(on_actionClone_Subtile_triggered()))->setToolTip("Add new tiles at the end based on the current one");
+    this->subtileMenu.addAction("Replace", this, SLOT(on_actionReplace_Subtile_triggered()))->setToolTip("Replace the current tile");
+    this->subtileMenu.addAction("Delete", this, SLOT(on_actionDel_Subtile_triggered()))->setToolTip("Delete the current tile");
     this->ui->menuEdit->addMenu(&this->subtileMenu);
 
     // Initialize 'Tile' submenu of 'Edit'
     this->tileMenu.setToolTipsVisible(true);
-    this->tileMenu.addAction("Create", this, SLOT(on_actionCreate_Tile_triggered()))->setToolTip("Create a new tile");
-    this->tileMenu.addAction("Insert", this, SLOT(on_actionInsert_Tile_triggered()))->setToolTip("Add new tiles before the current one");
-    this->tileMenu.addAction("Add", this, SLOT(on_actionAdd_Tile_triggered()))->setToolTip("Add new tiles at the end");
-    this->tileMenu.addAction("Clone", this, SLOT(on_actionClone_Tile_triggered()))->setToolTip("Add new tile at the end based on the current one");
-    this->tileMenu.addAction("Replace", this, SLOT(on_actionReplace_Tile_triggered()))->setToolTip("Replace the current tile");
-    this->tileMenu.addAction("Delete", this, SLOT(on_actionDel_Tile_triggered()))->setToolTip("Delete the current tile");
+    this->tileMenu.addAction("Create", this, SLOT(on_actionCreate_Tile_triggered()))->setToolTip("Create a new megatile");
+    this->tileMenu.addAction("Insert", this, SLOT(on_actionInsert_Tile_triggered()))->setToolTip("Add new megatiles before the current one");
+    this->tileMenu.addAction("Add", this, SLOT(on_actionAdd_Tile_triggered()))->setToolTip("Add new megatiles at the end");
+    this->tileMenu.addAction("Clone", this, SLOT(on_actionClone_Tile_triggered()))->setToolTip("Add new megatile at the end based on the current one");
+    this->tileMenu.addAction("Replace", this, SLOT(on_actionReplace_Tile_triggered()))->setToolTip("Replace the current megatile");
+    this->tileMenu.addAction("Delete", this, SLOT(on_actionDel_Tile_triggered()))->setToolTip("Delete the current megatile");
     this->ui->menuEdit->addMenu(&this->tileMenu);
 
     this->buildRecentFilesMenu();

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -161,8 +161,8 @@ private:
 
     QMenu newMenu = QMenu("New");
     QMenu frameMenu = QMenu("Frame");
-    QMenu subtileMenu = QMenu("Subtile");
-    QMenu tileMenu = QMenu("Tile");
+    QMenu subtileMenu = QMenu("Tile");
+    QMenu tileMenu = QMenu("MegaTile");
 
     QUndoStack *undoStack;
     QAction *undoAction;

--- a/source/mainwindow.ui
+++ b/source/mainwindow.ui
@@ -312,7 +312,7 @@
     <string>Usage Report</string>
    </property>
    <property name="toolTip">
-    <string>List the uses of the current frame/subtile/tile</string>
+    <string>List the uses of the current frame/tile/megatile</string>
    </property>
   </action>
   <action name="actionResetFrameTypes_Tileset">
@@ -328,7 +328,7 @@
     <string>Cleanup Frames</string>
    </property>
    <property name="toolTip">
-    <string>Delete frames not used by any subtile</string>
+    <string>Delete frames not used by any tile</string>
    </property>
   </action>
   <action name="actionCleanupSubtiles_Tileset">
@@ -336,7 +336,7 @@
     <string>Cleanup Tiles</string>
    </property>
    <property name="toolTip">
-    <string>Delete subtiles not used by any tile</string>
+    <string>Delete tiles not used by any megatile</string>
    </property>
   </action>
   <action name="actionCompressTileset_Tileset">
@@ -344,7 +344,7 @@
     <string>Deduplicate Tileset</string>
    </property>
    <property name="toolTip">
-    <string>Deduplicate frames and subtiles</string>
+    <string>Deduplicate frames and tiles</string>
    </property>
   </action>
   <action name="actionSortFrames_Tileset">
@@ -352,7 +352,7 @@
     <string>Sort Frames</string>
    </property>
    <property name="toolTip">
-    <string>Sort the frames based on the subtiles</string>
+    <string>Sort the frames based on the tiles</string>
    </property>
   </action>
   <action name="actionSortSubtiles_Tileset">
@@ -360,7 +360,7 @@
     <string>Sort Tiles</string>
    </property>
    <property name="toolTip">
-    <string>Sort the subtiles based on the tiles</string>
+    <string>Sort the tiles based on the megatiles</string>
    </property>
   </action>
   <action name="actionSave_PAL">


### PR DESCRIPTION
This patch cleans up a few different usages of subtile/tile naming in UI and aligns it with current megatile/tile naming that was introduced.