### PR TITLE
LevelCelView: Inform user when an image doesn't fit in tileset

### DIFF
--- a/source/levelcelview.cpp
+++ b/source/levelcelview.cpp
@@ -3,6 +3,9 @@
 #include <algorithm>
 #include <set>
 
+#include "d1image.h"
+#include "mainwindow.h"
+#include "ui_levelcelview.h"
 #include <QAction>
 #include <QDebug>
 #include <QFileInfo>
@@ -11,10 +14,6 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QMimeData>
-
-#include "d1image.h"
-#include "mainwindow.h"
-#include "ui_levelcelview.h"
 
 LevelCelView::LevelCelView(QWidget *parent)
     : QWidget(parent)
@@ -279,6 +278,13 @@ void LevelCelView::assignFrames(const QImage &image, int subtileIndex, int frame
 void LevelCelView::insertFrames(IMAGE_FILE_MODE mode, int index, const QImage &image)
 {
     if ((image.width() % MICRO_WIDTH) != 0 || (image.height() % MICRO_HEIGHT) != 0) {
+        QMessageBox::critical(this, tr("Error!"), tr("Wrong frame dimensions!\n"
+                                                     "Image should have dimensions %1x%2px (w x h).\n"
+                                                     "Image that you wanted to insert has %3x%4px dimensions.")
+                                                      .arg(MICRO_WIDTH)
+                                                      .arg(MICRO_HEIGHT)
+                                                      .arg(image.width())
+                                                      .arg(image.height()));
         return;
     }
 
@@ -400,6 +406,13 @@ void LevelCelView::insertSubtiles(IMAGE_FILE_MODE mode, int index, const QImage 
     unsigned subtileHeight = this->min->getSubtileHeight() * MICRO_HEIGHT;
 
     if ((image.width() % subtileWidth) != 0 || (image.height() % subtileHeight) != 0) {
+        QMessageBox::critical(this, tr("Error!"), tr("Wrong tile dimensions!\n"
+                                                     "Image should have dimensions %1x%2px (w x h).\n"
+                                                     "Image that you wanted to insert has %3x%4px dimensions.")
+                                                      .arg(subtileWidth)
+                                                      .arg(subtileHeight)
+                                                      .arg(image.width())
+                                                      .arg(image.height()));
         return;
     }
 
@@ -549,6 +562,13 @@ void LevelCelView::insertTiles(IMAGE_FILE_MODE mode, int index, const QImage &im
     unsigned tileHeight = this->min->getSubtileHeight() * MICRO_HEIGHT;
 
     if ((image.width() % tileWidth) != 0 || (image.height() % tileHeight) != 0) {
+        QMessageBox::critical(this, tr("Error!"), tr("Wrong MegaTile dimensions!\n"
+                                                     "Image should have dimensions %1x%2px (w x h).\n"
+                                                     "Image that you wanted to insert has %3x%4px dimensions.")
+                                                      .arg(tileWidth)
+                                                      .arg(tileHeight)
+                                                      .arg(image.width())
+                                                      .arg(image.height()));
         return;
     }
 

--- a/source/levelcelview.cpp
+++ b/source/levelcelview.cpp
@@ -572,14 +572,6 @@ void LevelCelView::insertTiles(IMAGE_FILE_MODE mode, int index, const QImage &im
         return;
     }
 
-    /*if (mode == IMAGE_FILE_MODE::AUTO
-        && (image.width() != subtileWidth || image.height() != subtileHeight) && image.width() != subtileWidth * EXPORT_TILES_PER_LINE) {
-        // not a column of tiles
-        // not a row or tiles
-        // not a grouped tiles from an export -> ignore
-        return;
-    }*/
-
     QImage subImage = QImage(tileWidth, tileHeight, QImage::Format_ARGB32);
     for (int y = 0; y < image.height(); y += tileHeight) {
         for (int x = 0; x < image.width(); x += tileWidth) {


### PR DESCRIPTION
Currently if user inserts an image to a tileset, with either drag'n'drop feature or by menus - there won't be any message that the image that he wants to insert is not fitting within the frame/tile/megatile dimensions. This patch adds those warnings.

Resolves: https://github.com/diasurgical/d1-graphics-tool/issues/111