### PR TITLE
MenuEdit: Add undo/redo options for frame ops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Widgets)
 include_directories(source/)
 set(PROJECT_SOURCES
         source/celview.cpp
+        source/framecmds.cpp
         source/config.cpp
         source/d1amp.cpp
         source/d1cel.cpp

--- a/source/celview.h
+++ b/source/celview.h
@@ -55,6 +55,8 @@ public:
 
     void initialize(D1Gfx *gfx);
     void sendRemoveFrameCmd();
+    void sendAddFrameCmd(IMAGE_FILE_MODE mode, int index, const QString &imagefilePath);
+    void updateCurrentFrameIndex(int frameIdx);
     int getCurrentFrameIndex();
     void framePixelClicked(unsigned x, unsigned y);
     void insertImageFiles(IMAGE_FILE_MODE mode, const QStringList &imagefilePaths, bool append);
@@ -71,7 +73,8 @@ signals:
 
 private:
     void update();
-    void insertFrame(IMAGE_FILE_MODE mode, int index, const QString &imagefilePath);
+    void removeFrames(int startingIndex, int endingIndex);
+    void insertFrames(int startingIndex, const std::vector<QImage> &images);
     void setGroupIndex();
 
 private slots:

--- a/source/celview.h
+++ b/source/celview.h
@@ -60,7 +60,8 @@ public:
     int getCurrentFrameIndex();
     void framePixelClicked(unsigned x, unsigned y);
     void insertImageFiles(IMAGE_FILE_MODE mode, const QStringList &imagefilePaths, bool append);
-    void replaceCurrentFrame(const QString &imagefilePath);
+    void sendReplaceCurrentFrameCmd(const QString &imagefilePath);
+    void replaceCurrentFrame(int frameIdx, const QImage &image);
     void removeCurrentFrame(int frameIdx);
     void regroupFrames(int numGroups);
     void updateGroupIndex();

--- a/source/d1gfx.h
+++ b/source/d1gfx.h
@@ -4,6 +4,8 @@
 #include <QMap>
 #include <QtEndian>
 
+#include <optional>
+
 #include "d1celtilesetframe.h"
 #include "d1pal.h"
 
@@ -72,9 +74,10 @@ public:
     ~D1Gfx() = default;
 
     QImage getFrameImage(quint16 frameIndex);
-    D1GfxFrame *insertFrame(int frameIndex, const QImage &image);
+    D1GfxFrame *insertFrame(int frameIdx, const QImage &image);
+    void insertFrameInGroup(int frameIdx, int groupIdx, const QImage &image);
     D1GfxFrame *replaceFrame(int frameIndex, const QImage &image);
-    void removeFrame(quint16 frameIndex);
+    std::optional<int> removeFrame(quint16 frameIndex);
     void regroupFrames(int count);
     void remapFrames(const QMap<unsigned, unsigned> &remap);
 
@@ -86,6 +89,7 @@ public:
     QString getFilePath();
     D1Pal *getPalette();
     void setPalette(D1Pal *pal);
+    void insertGroup(int groupIdx, int frameIdx, const QImage &image);
     int getGroupCount();
     QPair<quint16, quint16> getGroupFrameIndices(int groupIndex);
     int getFrameCount();

--- a/source/framecmds.cpp
+++ b/source/framecmds.cpp
@@ -1,16 +1,18 @@
 #include "framecmds.h"
 
-RemoveFrameCommand::RemoveFrameCommand(D1Gfx *g, CelView *cv, QUndoCommand *parent)
-    : gfx(g)
-    , celview(cv)
-    , QUndoCommand(parent)
+RemoveFrameCommand::RemoveFrameCommand(int currentFrameIndex, const QImage img, QUndoCommand *parent)
+    : frameIndexToRevert(currentFrameIndex)
+    , imgToRevert(img)
 {
 }
 
 void RemoveFrameCommand::undo()
 {
+    emit this->inserted(frameIndexToRevert, imgToRevert);
 }
 
 void RemoveFrameCommand::redo()
 {
+    // emit this signal which will call LevelCelView/CelView::removeCurrentFrame
+    emit this->removed(frameIndexToRevert);
 }

--- a/source/framecmds.cpp
+++ b/source/framecmds.cpp
@@ -22,6 +22,24 @@ void RemoveFrameCommand::redo()
     emit this->removed(frameIndexToRevert);
 }
 
+ReplaceFrameCommand::ReplaceFrameCommand(int currentFrameIndex, const QImage imgToReplace, const QImage imgToRestore, QUndoCommand *parent)
+    : frameIndexToReplace(currentFrameIndex)
+    , imgToReplace(imgToReplace)
+    , imgToRestore(imgToRestore)
+{
+}
+
+void ReplaceFrameCommand::undo()
+{
+    emit this->undoReplaced(frameIndexToReplace, imgToRestore);
+}
+
+void ReplaceFrameCommand::redo()
+{
+    // emit this signal which will call LevelCelView/CelView::replaceCurrentFrame
+    emit this->replaced(frameIndexToReplace, imgToReplace);
+}
+
 AddFrameCommand::AddFrameCommand(IMAGE_FILE_MODE mode, int index, const QString imagefilePath, QUndoCommand *parent)
     : startingIndex(index)
     , mode(mode)

--- a/source/framecmds.cpp
+++ b/source/framecmds.cpp
@@ -1,0 +1,16 @@
+#include "framecmds.h"
+
+RemoveFrameCommand::RemoveFrameCommand(D1Gfx *g, CelView *cv, QUndoCommand *parent)
+    : gfx(g)
+    , celview(cv)
+    , QUndoCommand(parent)
+{
+}
+
+void RemoveFrameCommand::undo()
+{
+}
+
+void RemoveFrameCommand::redo()
+{
+}

--- a/source/framecmds.cpp
+++ b/source/framecmds.cpp
@@ -1,4 +1,9 @@
+#include <QImageReader>
+
+#include <stdexcept>
+
 #include "framecmds.h"
+#include "mainwindow.h"
 
 RemoveFrameCommand::RemoveFrameCommand(int currentFrameIndex, const QImage img, QUndoCommand *parent)
     : frameIndexToRevert(currentFrameIndex)
@@ -15,4 +20,41 @@ void RemoveFrameCommand::redo()
 {
     // emit this signal which will call LevelCelView/CelView::removeCurrentFrame
     emit this->removed(frameIndexToRevert);
+}
+
+AddFrameCommand::AddFrameCommand(IMAGE_FILE_MODE mode, int index, const QString imagefilePath, QUndoCommand *parent)
+    : startingIndex(index)
+    , mode(mode)
+{
+    QImageReader reader = QImageReader(imagefilePath);
+    int numImages = 0;
+
+    // FIXME: this loop should have some sort of a progress bar, we support
+    // status bar, but if user loads a .gif which could contain up to hundreds
+    // of frames, loading might take quite a bit
+    while (true) {
+        QImage image = reader.read();
+        if (image.isNull()) {
+            break;
+        }
+
+        images.emplace_back(image);
+        numImages++;
+    }
+
+    if (mode != IMAGE_FILE_MODE::AUTO && numImages == 0) {
+        throw std::exception();
+    }
+
+    endingIndex = startingIndex + numImages;
+}
+
+void AddFrameCommand::undo()
+{
+    emit this->undoAdded(startingIndex, endingIndex);
+}
+
+void AddFrameCommand::redo()
+{
+    emit this->added(startingIndex, images, mode);
 }

--- a/source/framecmds.h
+++ b/source/framecmds.h
@@ -23,6 +23,26 @@ private:
     int frameIndexToRevert = 0;
 };
 
+class ReplaceFrameCommand : public QObject, public QUndoCommand {
+    Q_OBJECT
+
+public:
+    explicit ReplaceFrameCommand(int currentFrameIndex, const QImage imgToReplace, const QImage imgToRestore, QUndoCommand *parent = nullptr);
+    ~ReplaceFrameCommand() = default;
+
+    void undo() override;
+    void redo() override;
+
+signals:
+    void undoReplaced(int idxToRemove, const QImage imgToRestore);
+    void replaced(int idxToReplace, const QImage imgToReplace);
+
+private:
+    QImage imgToReplace;
+    QImage imgToRestore;
+    int frameIndexToReplace = 0;
+};
+
 class AddFrameCommand : public QObject, public QUndoCommand {
     Q_OBJECT
 

--- a/source/framecmds.h
+++ b/source/framecmds.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "celview.h"
+#include <QObject>
+#include <QUndoCommand>
+
+class RemoveFrameCommand : public QObject, public QUndoCommand {
+    Q_OBJECT
+
+public:
+    explicit RemoveFrameCommand(D1Gfx *g, CelView *cv, QUndoCommand *parent = nullptr);
+    ~RemoveFrameCommand() = default;
+
+    void undo() override;
+    void redo() override;
+
+private:
+    QPointer<D1Gfx> gfx;
+    QPointer<CelView> celview;
+    QImage img;
+    int currentFrameIndex = 0;
+};

--- a/source/framecmds.h
+++ b/source/framecmds.h
@@ -22,3 +22,24 @@ private:
     QImage imgToRevert;
     int frameIndexToRevert = 0;
 };
+
+class AddFrameCommand : public QObject, public QUndoCommand {
+    Q_OBJECT
+
+public:
+    explicit AddFrameCommand(IMAGE_FILE_MODE mode, int index, const QString imagefilePath, QUndoCommand *parent = nullptr);
+    ~AddFrameCommand() = default;
+
+    void undo() override;
+    void redo() override;
+
+signals:
+    void undoAdded(int startingIndex, int endingIndex);
+    void added(int startingIndex, const std::vector<QImage> &images, IMAGE_FILE_MODE mode);
+
+private:
+    std::vector<QImage> images;
+    int startingIndex = 0;
+    int endingIndex = 0;
+    IMAGE_FILE_MODE mode;
+};

--- a/source/framecmds.h
+++ b/source/framecmds.h
@@ -8,15 +8,17 @@ class RemoveFrameCommand : public QObject, public QUndoCommand {
     Q_OBJECT
 
 public:
-    explicit RemoveFrameCommand(D1Gfx *g, CelView *cv, QUndoCommand *parent = nullptr);
+    explicit RemoveFrameCommand(int currentFrameIndex, const QImage img, QUndoCommand *parent = nullptr);
     ~RemoveFrameCommand() = default;
 
     void undo() override;
     void redo() override;
 
+signals:
+    void removed(int idxToRemove);
+    void inserted(int idxToRestore, const QImage imgToRestore);
+
 private:
-    QPointer<D1Gfx> gfx;
-    QPointer<CelView> celview;
-    QImage img;
-    int currentFrameIndex = 0;
+    QImage imgToRevert;
+    int frameIndexToRevert = 0;
 };

--- a/source/levelcelview.h
+++ b/source/levelcelview.h
@@ -51,13 +51,15 @@ public:
     int getCurrentFrameIndex();
     int getCurrentSubtileIndex();
     int getCurrentTileIndex();
-    void replaceCurrentFrame(const QString &imagefilePath);
 
     void framePixelClicked(unsigned x, unsigned y);
 
     void insertImageFiles(IMAGE_FILE_MODE mode, const QStringList &imagefilePaths, bool append);
 
     void sendAddFrameCmd(IMAGE_FILE_MODE mode, int index, const QString &imagefilePath);
+
+    void sendReplaceCurrentFrameCmd(const QString &imagefilePath);
+    void replaceCurrentFrame(int frameIdx, const QImage &image);
 
     void sendRemoveFrameCmd();
     void removeCurrentFrame(int idx);

--- a/source/levelcelview.h
+++ b/source/levelcelview.h
@@ -51,12 +51,14 @@ public:
     int getCurrentFrameIndex();
     int getCurrentSubtileIndex();
     int getCurrentTileIndex();
+    void replaceCurrentFrame(const QString &imagefilePath);
 
     void framePixelClicked(unsigned x, unsigned y);
 
     void insertImageFiles(IMAGE_FILE_MODE mode, const QStringList &imagefilePaths, bool append);
 
-    void replaceCurrentFrame(const QString &imagefilePath);
+    void sendAddFrameCmd(IMAGE_FILE_MODE mode, int index, const QString &imagefilePath);
+
     void sendRemoveFrameCmd();
     void removeCurrentFrame(int idx);
 
@@ -86,8 +88,8 @@ private:
     void collectFrameUsers(int frameIndex, QList<int> &users) const;
     void collectSubtileUsers(int subtileIndex, QList<int> &users) const;
     void insertFrame(IMAGE_FILE_MODE mode, int index, const QImage &image);
-    void insertFrames(IMAGE_FILE_MODE mode, int index, const QString &imagefilePath);
     void insertFrames(IMAGE_FILE_MODE mode, const QStringList &imagefilePaths, bool append);
+    void insertFrames(int startingIndex, const std::vector<QImage> &images, IMAGE_FILE_MODE mode);
     void insertSubtile(int subtileIndex, const QImage &image);
     void insertSubtiles(IMAGE_FILE_MODE mode, int index, const QImage &image);
     void insertSubtiles(IMAGE_FILE_MODE mode, int index, const QString &imagefilePath);
@@ -99,6 +101,7 @@ private:
     void assignFrames(const QImage &image, int subtileIndex, int frameIndex);
     void assignSubtiles(const QImage &image, int tileIndex, int subtileIndex);
     void removeFrame(int frameIndex);
+    void removeFrames(int startingIdx, int endingIndex);
     void removeSubtile(int subtileIndex);
     void removeUnusedFrames(QString &report);
     void removeUnusedSubtiles(QString &report);

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -47,7 +47,7 @@ MainWindow::MainWindow()
     this->ui->menuFile->insertMenu(firstFileAction, &this->newMenu);
 
     // Initialize 'Undo/Redo' of 'Edit
-    this->undoStack = new QUndoStack(this);
+    this->undoStack = std::make_shared<QUndoStack>(this);
     this->undoAction = undoStack->createUndoAction(this, "Undo");
     this->undoAction->setShortcuts(QKeySequence::Undo);
     this->ui->menuEdit->addAction(this->undoAction);
@@ -102,7 +102,6 @@ MainWindow::~MainWindow()
     Config::insert("LastFilePath", this->lastFilePath);
     // cleanup memory
     delete ui;
-    delete this->undoStack;
     delete this->undoAction;
     delete this->redoAction;
 }
@@ -149,7 +148,8 @@ void MainWindow::updateWindow()
     // rebuild palette hits
     this->palHits->update();
     this->palWidget->refresh();
-    this->undoStack->clear();
+    this->undoAction->setEnabled(this->undoStack->canUndo());
+
     // update menu options
     bool hasFrame = this->gfx->getFrameCount() != 0;
     this->frameMenu.actions()[2]->setEnabled(hasFrame); // replace frame
@@ -614,7 +614,7 @@ void MainWindow::openFile(const OpenAsParam &params)
     QObject::connect(this->trn1Widget, &PaletteWidget::clearRootBorder, this->trn2Widget, &PaletteWidget::clearBorder);
 
     if (isTileset) {
-        this->levelCelView = new LevelCelView();
+        this->levelCelView = new LevelCelView(this->undoStack);
         this->levelCelView->initialize(this->gfx, this->min, this->til, this->sol, this->amp);
 
         // Refresh CEL view if a PAL or TRN is modified
@@ -640,7 +640,7 @@ void MainWindow::openFile(const OpenAsParam &params)
     }
     // Otherwise build a CelView
     else {
-        this->celView = new CelView();
+        this->celView = new CelView(this->undoStack);
         this->celView->initialize(this->gfx);
 
         // Refresh CEL view if a PAL or TRN is modified
@@ -1098,10 +1098,10 @@ void MainWindow::on_actionReplace_Frame_triggered()
 void MainWindow::on_actionDel_Frame_triggered()
 {
     if (this->celView != nullptr) {
-        this->celView->removeCurrentFrame();
+        this->celView->sendRemoveFrameCmd();
     }
     if (this->levelCelView != nullptr) {
-        this->levelCelView->removeCurrentFrame();
+        this->levelCelView->sendRemoveFrameCmd();
     }
     this->updateWindow();
 }

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -1084,10 +1084,10 @@ void MainWindow::on_actionReplace_Frame_triggered()
     this->ui->statusBar->repaint();
 
     if (this->celView != nullptr) {
-        this->celView->replaceCurrentFrame(imgFilePath);
+        this->celView->sendReplaceCurrentFrameCmd(imgFilePath);
     }
     if (this->levelCelView != nullptr) {
-        this->levelCelView->replaceCurrentFrame(imgFilePath);
+        this->levelCelView->sendReplaceCurrentFrameCmd(imgFilePath);
     }
     this->updateWindow();
 

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -7,6 +7,8 @@
 #include <QStringList>
 #include <QUndoCommand>
 
+#include <memory>
+
 #include "celview.h"
 #include "d1gfx.h"
 #include "d1min.h"
@@ -164,7 +166,7 @@ private:
     QMenu subtileMenu = QMenu("Tile");
     QMenu tileMenu = QMenu("MegaTile");
 
-    QUndoStack *undoStack;
+    std::shared_ptr<QUndoStack> undoStack;
     QAction *undoAction;
     QAction *redoAction;
 

--- a/source/palettewidget.cpp
+++ b/source/palettewidget.cpp
@@ -265,7 +265,7 @@ QPushButton *PaletteWidget::addButton(QStyle::StandardPixmap type, QString toolt
     return button;
 }
 
-PaletteWidget::PaletteWidget(QUndoStack *us, QString title)
+PaletteWidget::PaletteWidget(std::shared_ptr<QUndoStack> us, QString title)
     : QWidget(nullptr)
     , undoStack(us)
     , ui(new Ui::PaletteWidget())

--- a/source/palettewidget.h
+++ b/source/palettewidget.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #include <QDirIterator>
 #include <QGraphicsScene>
 #include <QMouseEvent>
@@ -123,7 +125,7 @@ class PaletteWidget : public QWidget {
     Q_OBJECT
 
 public:
-    explicit PaletteWidget(QUndoStack *undoStack, QString title);
+    explicit PaletteWidget(std::shared_ptr<QUndoStack> undoStack, QString title);
     ~PaletteWidget();
 
     void setPal(D1Pal *p);
@@ -214,7 +216,7 @@ private slots:
     void on_monsterTrnPushButton_clicked();
 
 private:
-    QUndoStack *undoStack;
+    std::shared_ptr<QUndoStack> undoStack;
     Ui::PaletteWidget *ui;
     bool isTrn;
 


### PR DESCRIPTION
This patch adds undo stack for frame options in "Edit" menu in the app. Currently, if we try to remove frame/insert/append/replace frame, it's possible, although we can't revert the result that we've acquired. This patch adds this possibility for the following options:
- removing frames
- replacing frames
- inserting frames
- appending frames

While this patch might work by itself, there may be some dependencies  with different operations in the app, like adding tiles or megatiles. Those will be supported in undo stack in the next PRs that will come.