### PR TITLE
LevelCelView: Fix frame not being displayed properly in Tile/Megatile

### DIFF
--- a/source/levelcelview.cpp
+++ b/source/levelcelview.cpp
@@ -1576,7 +1576,7 @@ void LevelCelView::on_firstFrameButton_clicked()
     this->currentFrameIndex = 0;
 
     if (this->mode == TILESET_MODE::SUBTILE) {
-        this->min->getCelFrameIndices(this->currentSubtileIndex)[this->editIndex] = this->currentFrameIndex;
+        this->min->getCelFrameIndices(this->currentSubtileIndex)[this->editIndex] = this->currentFrameIndex + 1;
     } else {
         this->mode = TILESET_MODE::FREE;
         this->update();
@@ -1593,7 +1593,7 @@ void LevelCelView::on_previousFrameButton_clicked()
         this->currentFrameIndex = std::max(0, this->gfx->getFrameCount() - 1);
 
     if (this->mode == TILESET_MODE::SUBTILE) {
-        this->min->getCelFrameIndices(this->currentSubtileIndex)[this->editIndex] = this->currentFrameIndex;
+        this->min->getCelFrameIndices(this->currentSubtileIndex)[this->editIndex] = this->currentFrameIndex + 1;
     } else {
         this->mode = TILESET_MODE::FREE;
         this->update();
@@ -1610,7 +1610,7 @@ void LevelCelView::on_nextFrameButton_clicked()
         this->currentFrameIndex = 0;
 
     if (this->mode == TILESET_MODE::SUBTILE) {
-        this->min->getCelFrameIndices(this->currentSubtileIndex)[this->editIndex] = this->currentFrameIndex;
+        this->min->getCelFrameIndices(this->currentSubtileIndex)[this->editIndex] = this->currentFrameIndex + 1;
     } else {
         this->mode = TILESET_MODE::FREE;
         this->update();
@@ -1624,7 +1624,7 @@ void LevelCelView::on_lastFrameButton_clicked()
     this->currentFrameIndex = std::max(0, this->gfx->getFrameCount() - 1);
 
     if (this->mode == TILESET_MODE::SUBTILE) {
-        this->min->getCelFrameIndices(this->currentSubtileIndex)[this->editIndex] = this->currentFrameIndex;
+        this->min->getCelFrameIndices(this->currentSubtileIndex)[this->editIndex] = this->currentFrameIndex + 1;
     } else {
         this->mode = TILESET_MODE::FREE;
         this->update();


### PR DESCRIPTION
This patch fixes the incorrect behaviour where we click on tile/megatile, selecting a certain frame, and then after pressing "next/previous/first/last frame button" frame in the frame preview is not the same one displayed in tile/megatile view.

This is caused by the celFrameIndices QList in D1Min class, which holds frame indices starting from 1, not 0. This patch adds 1 to all the frame indices when they are selected from QList in D1Min class, so the offset is the same one as it is in LevelCelView.