### PR TITLE
MenuEdit: Do not use autoconnection mechanism for slots used in QMenu

### DIFF
--- a/source/celview.cpp
+++ b/source/celview.cpp
@@ -316,17 +316,17 @@ void CelView::ShowContextMenu(const QPoint &pos)
 
     QAction action0("Insert Frame", this);
     action0.setToolTip("Add new frames before the current one");
-    QObject::connect(&action0, SIGNAL(triggered()), mw, SLOT(on_actionInsert_Frame_triggered()));
+    QObject::connect(&action0, SIGNAL(triggered()), mw, SLOT(actionInsertFrame_triggered()));
     contextMenu.addAction(&action0);
 
     QAction action1("Add Frame", this);
     action1.setToolTip("Add new frames at the end");
-    QObject::connect(&action1, SIGNAL(triggered()), mw, SLOT(on_actionAdd_Frame_triggered()));
+    QObject::connect(&action1, SIGNAL(triggered()), mw, SLOT(actionAddFrame_triggered()));
     contextMenu.addAction(&action1);
 
     QAction action2("Replace Frame", this);
     action2.setToolTip("Replace the current frame");
-    QObject::connect(&action2, SIGNAL(triggered()), mw, SLOT(on_actionReplace_Frame_triggered()));
+    QObject::connect(&action2, SIGNAL(triggered()), mw, SLOT(actionReplaceFrame_triggered()));
     if (this->gfx->getFrameCount() == 0) {
         action2.setEnabled(false);
     }
@@ -334,7 +334,7 @@ void CelView::ShowContextMenu(const QPoint &pos)
 
     QAction action3("Del Frame", this);
     action3.setToolTip("Delete the current frame");
-    QObject::connect(&action3, SIGNAL(triggered()), mw, SLOT(on_actionDel_Frame_triggered()));
+    QObject::connect(&action3, SIGNAL(triggered()), mw, SLOT(actionDelFrame_triggered()));
     if (this->gfx->getFrameCount() == 0) {
         action3.setEnabled(false);
     }

--- a/source/levelcelview.cpp
+++ b/source/levelcelview.cpp
@@ -1467,17 +1467,17 @@ void LevelCelView::ShowContextMenu(const QPoint &pos)
 
     QAction action0("Insert", this);
     action0.setToolTip("Add new frames before the current one");
-    QObject::connect(&action0, SIGNAL(triggered()), mw, SLOT(on_actionInsert_Frame_triggered()));
+    QObject::connect(&action0, SIGNAL(triggered()), mw, SLOT(actionInsertFrame_triggered()));
     frameMenu.addAction(&action0);
 
     QAction action1("Add", this);
     action1.setToolTip("Add new frames at the end");
-    QObject::connect(&action1, SIGNAL(triggered()), mw, SLOT(on_actionAdd_Frame_triggered()));
+    QObject::connect(&action1, SIGNAL(triggered()), mw, SLOT(actionAddFrame_triggered()));
     frameMenu.addAction(&action1);
 
     QAction action2("Replace", this);
     action2.setToolTip("Replace the current frame");
-    QObject::connect(&action2, SIGNAL(triggered()), mw, SLOT(on_actionReplace_Frame_triggered()));
+    QObject::connect(&action2, SIGNAL(triggered()), mw, SLOT(actionReplaceFrame_triggered()));
     if (this->gfx->getFrameCount() == 0) {
         action2.setEnabled(false);
     }
@@ -1485,7 +1485,7 @@ void LevelCelView::ShowContextMenu(const QPoint &pos)
 
     QAction action3("Delete", this);
     action3.setToolTip("Delete the current frame");
-    QObject::connect(&action3, SIGNAL(triggered()), mw, SLOT(on_actionDel_Frame_triggered()));
+    QObject::connect(&action3, SIGNAL(triggered()), mw, SLOT(actionDelFrame_triggered()));
     if (this->gfx->getFrameCount() == 0) {
         action3.setEnabled(false);
     }
@@ -1498,22 +1498,22 @@ void LevelCelView::ShowContextMenu(const QPoint &pos)
 
     QAction action4("Create", this);
     action4.setToolTip("Create a new subtile");
-    QObject::connect(&action4, SIGNAL(triggered()), mw, SLOT(on_actionCreate_Subtile_triggered()));
+    QObject::connect(&action4, SIGNAL(triggered()), mw, SLOT(actionCreateSubtile_triggered()));
     subtileMenu.addAction(&action4);
 
     QAction action5("Insert", this);
     action5.setToolTip("Add new subtiles before the current one");
-    QObject::connect(&action5, SIGNAL(triggered()), mw, SLOT(on_actionInsert_Subtile_triggered()));
+    QObject::connect(&action5, SIGNAL(triggered()), mw, SLOT(actionInsertSubtile_triggered()));
     subtileMenu.addAction(&action5);
 
     QAction action6("Add", this);
     action6.setToolTip("Add new subtiles at the end");
-    QObject::connect(&action6, SIGNAL(triggered()), mw, SLOT(on_actionAdd_Subtile_triggered()));
+    QObject::connect(&action6, SIGNAL(triggered()), mw, SLOT(actionAddSubtile_triggered()));
     subtileMenu.addAction(&action6);
 
     QAction action7("Replace", this);
     action7.setToolTip("Replace the current subtile");
-    QObject::connect(&action7, SIGNAL(triggered()), mw, SLOT(on_actionReplace_Subtile_triggered()));
+    QObject::connect(&action7, SIGNAL(triggered()), mw, SLOT(actionReplaceSubtile_triggered()));
     if (this->min->getSubtileCount() == 0) {
         action7.setEnabled(false);
     }
@@ -1521,7 +1521,7 @@ void LevelCelView::ShowContextMenu(const QPoint &pos)
 
     QAction action8("Delete", this);
     action8.setToolTip("Delete the current subtile");
-    QObject::connect(&action8, SIGNAL(triggered()), mw, SLOT(on_actionDel_Subtile_triggered()));
+    QObject::connect(&action8, SIGNAL(triggered()), mw, SLOT(actionDelSubtile_triggered()));
     if (this->min->getSubtileCount() == 0) {
         action8.setEnabled(false);
     }
@@ -1534,7 +1534,7 @@ void LevelCelView::ShowContextMenu(const QPoint &pos)
 
     QAction action9("Create", this);
     action9.setToolTip("Create a new tile");
-    QObject::connect(&action9, SIGNAL(triggered()), mw, SLOT(on_actionCreate_Tile_triggered()));
+    QObject::connect(&action9, SIGNAL(triggered()), mw, SLOT(actionCreateTile_triggered()));
     if (this->min->getSubtileCount() == 0) {
         action9.setEnabled(false);
     }
@@ -1542,17 +1542,17 @@ void LevelCelView::ShowContextMenu(const QPoint &pos)
 
     QAction action10("Insert", this);
     action10.setToolTip("Add new tiles before the current one");
-    QObject::connect(&action10, SIGNAL(triggered()), mw, SLOT(on_actionInsert_Tile_triggered()));
+    QObject::connect(&action10, SIGNAL(triggered()), mw, SLOT(actionInsertTile_triggered()));
     tileMenu.addAction(&action10);
 
     QAction action11("Add", this);
     action11.setToolTip("Add new tiles at the end");
-    QObject::connect(&action11, SIGNAL(triggered()), mw, SLOT(on_actionAdd_Tile_triggered()));
+    QObject::connect(&action11, SIGNAL(triggered()), mw, SLOT(actionAddTile_triggered()));
     tileMenu.addAction(&action11);
 
     QAction action12("Replace", this);
     action12.setToolTip("Replace the current tile");
-    QObject::connect(&action12, SIGNAL(triggered()), mw, SLOT(on_actionReplace_Tile_triggered()));
+    QObject::connect(&action12, SIGNAL(triggered()), mw, SLOT(actionReplaceTile_triggered()));
     if (this->til->getTileCount() == 0) {
         action12.setEnabled(false);
     }
@@ -1560,7 +1560,7 @@ void LevelCelView::ShowContextMenu(const QPoint &pos)
 
     QAction action13("Delete", this);
     action13.setToolTip("Delete the current tile");
-    QObject::connect(&action13, SIGNAL(triggered()), mw, SLOT(on_actionDel_Tile_triggered()));
+    QObject::connect(&action13, SIGNAL(triggered()), mw, SLOT(actionDelTile_triggered()));
     if (this->til->getTileCount() == 0) {
         action13.setEnabled(false);
     }

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -41,8 +41,8 @@ MainWindow::MainWindow()
     this->setWindowTitle(D1_GRAPHICS_TOOL_TITLE);
 
     // initialize 'new' submenu of 'File'
-    this->newMenu.addAction("Sprite", this, SLOT(on_actionNew_Sprite_triggered()));
-    this->newMenu.addAction("Tileset", this, SLOT(on_actionNew_Tileset_triggered()));
+    this->newMenu.addAction("Sprite", this, SLOT(actionNewSprite_triggered()));
+    this->newMenu.addAction("Tileset", this, SLOT(actionNewTileset_triggered()));
     QAction *firstFileAction = (QAction *)this->ui->menuFile->actions()[0];
     this->ui->menuFile->insertMenu(firstFileAction, &this->newMenu);
 
@@ -62,30 +62,30 @@ MainWindow::MainWindow()
 
     // Initialize 'Frame' submenu of 'Edit'
     this->frameMenu.setToolTipsVisible(true);
-    this->frameMenu.addAction("Insert", this, SLOT(on_actionInsert_Frame_triggered()))->setToolTip("Add new frames before the current one");
-    this->frameMenu.addAction("Add", this, SLOT(on_actionAdd_Frame_triggered()))->setToolTip("Add new frames at the end");
-    this->frameMenu.addAction("Replace", this, SLOT(on_actionReplace_Frame_triggered()))->setToolTip("Replace the current frame");
-    this->frameMenu.addAction("Delete", this, SLOT(on_actionDel_Frame_triggered()))->setToolTip("Delete the current frame");
+    this->frameMenu.addAction("Insert", this, SLOT(actionInsertFrame_triggered()))->setToolTip("Add new frames before the current one");
+    this->frameMenu.addAction("Add", this, SLOT(actionAddFrame_triggered()))->setToolTip("Add new frames at the end");
+    this->frameMenu.addAction("Replace", this, SLOT(actionReplaceFrame_triggered()))->setToolTip("Replace the current frame");
+    this->frameMenu.addAction("Delete", this, SLOT(actionDelFrame_triggered()))->setToolTip("Delete the current frame");
     this->ui->menuEdit->addMenu(&this->frameMenu);
 
     // Initialize 'Subtile' submenu of 'Edit'
     this->subtileMenu.setToolTipsVisible(true);
-    this->subtileMenu.addAction("Create", this, SLOT(on_actionCreate_Subtile_triggered()))->setToolTip("Create a new tile");
-    this->subtileMenu.addAction("Insert", this, SLOT(on_actionInsert_Subtile_triggered()))->setToolTip("Add new tiles before the current one");
-    this->subtileMenu.addAction("Add", this, SLOT(on_actionAdd_Subtile_triggered()))->setToolTip("Add new tiles at the end");
-    this->subtileMenu.addAction("Clone", this, SLOT(on_actionClone_Subtile_triggered()))->setToolTip("Add new tiles at the end based on the current one");
-    this->subtileMenu.addAction("Replace", this, SLOT(on_actionReplace_Subtile_triggered()))->setToolTip("Replace the current tile");
-    this->subtileMenu.addAction("Delete", this, SLOT(on_actionDel_Subtile_triggered()))->setToolTip("Delete the current tile");
+    this->subtileMenu.addAction("Create", this, SLOT(actionCreateSubtile_triggered()))->setToolTip("Create a new tile");
+    this->subtileMenu.addAction("Insert", this, SLOT(actionInsertSubtile_triggered()))->setToolTip("Add new tiles before the current one");
+    this->subtileMenu.addAction("Add", this, SLOT(actionAddSubtile_triggered()))->setToolTip("Add new tiles at the end");
+    this->subtileMenu.addAction("Clone", this, SLOT(actionCloneSubtile_triggered()))->setToolTip("Add new tiles at the end based on the current one");
+    this->subtileMenu.addAction("Replace", this, SLOT(actionReplaceSubtile_triggered()))->setToolTip("Replace the current tile");
+    this->subtileMenu.addAction("Delete", this, SLOT(actionDelSubtile_triggered()))->setToolTip("Delete the current tile");
     this->ui->menuEdit->addMenu(&this->subtileMenu);
 
     // Initialize 'Tile' submenu of 'Edit'
     this->tileMenu.setToolTipsVisible(true);
-    this->tileMenu.addAction("Create", this, SLOT(on_actionCreate_Tile_triggered()))->setToolTip("Create a new megatile");
-    this->tileMenu.addAction("Insert", this, SLOT(on_actionInsert_Tile_triggered()))->setToolTip("Add new megatiles before the current one");
-    this->tileMenu.addAction("Add", this, SLOT(on_actionAdd_Tile_triggered()))->setToolTip("Add new megatiles at the end");
-    this->tileMenu.addAction("Clone", this, SLOT(on_actionClone_Tile_triggered()))->setToolTip("Add new megatile at the end based on the current one");
-    this->tileMenu.addAction("Replace", this, SLOT(on_actionReplace_Tile_triggered()))->setToolTip("Replace the current megatile");
-    this->tileMenu.addAction("Delete", this, SLOT(on_actionDel_Tile_triggered()))->setToolTip("Delete the current megatile");
+    this->tileMenu.addAction("Create", this, SLOT(actionCreateTile_triggered()))->setToolTip("Create a new megatile");
+    this->tileMenu.addAction("Insert", this, SLOT(actionInsertTile_triggered()))->setToolTip("Add new megatiles before the current one");
+    this->tileMenu.addAction("Add", this, SLOT(actionAddTile_triggered()))->setToolTip("Add new megatiles at the end");
+    this->tileMenu.addAction("Clone", this, SLOT(actionCloneTile_triggered()))->setToolTip("Add new megatile at the end based on the current one");
+    this->tileMenu.addAction("Replace", this, SLOT(actionReplaceTile_triggered()))->setToolTip("Replace the current megatile");
+    this->tileMenu.addAction("Delete", this, SLOT(actionDelTile_triggered()))->setToolTip("Delete the current megatile");
     this->ui->menuEdit->addMenu(&this->tileMenu);
 
     this->buildRecentFilesMenu();
@@ -380,14 +380,14 @@ bool MainWindow::hasImageUrl(const QMimeData *mimeData)
     return false;
 }
 
-void MainWindow::on_actionNew_Sprite_triggered()
+void MainWindow::actionNewSprite_triggered()
 {
     OpenAsParam params;
     params.isTileset = OPEN_TILESET_TYPE::No;
     this->openFile(params);
 }
 
-void MainWindow::on_actionNew_Tileset_triggered()
+void MainWindow::actionNewTileset_triggered()
 {
     OpenAsParam params;
     params.isTileset = OPEN_TILESET_TYPE::Yes;
@@ -1061,17 +1061,17 @@ void MainWindow::closeEvent(QCloseEvent *event)
     event->accept();
 }
 
-void MainWindow::on_actionInsert_Frame_triggered()
+void MainWindow::actionInsertFrame_triggered()
 {
     this->addFrames(false);
 }
 
-void MainWindow::on_actionAdd_Frame_triggered()
+void MainWindow::actionAddFrame_triggered()
 {
     this->addFrames(true);
 }
 
-void MainWindow::on_actionReplace_Frame_triggered()
+void MainWindow::actionReplaceFrame_triggered()
 {
     QString filter = imageNameFilter();
     QString imgFilePath = this->fileDialog(FILE_DIALOG_MODE::OPEN, "Replacement Image File", filter.toLatin1().data());
@@ -1095,7 +1095,7 @@ void MainWindow::on_actionReplace_Frame_triggered()
     this->ui->statusBar->clearMessage();
 }
 
-void MainWindow::on_actionDel_Frame_triggered()
+void MainWindow::actionDelFrame_triggered()
 {
     if (this->celView != nullptr) {
         this->celView->removeCurrentFrame();
@@ -1106,29 +1106,29 @@ void MainWindow::on_actionDel_Frame_triggered()
     this->updateWindow();
 }
 
-void MainWindow::on_actionCreate_Subtile_triggered()
+void MainWindow::actionCreateSubtile_triggered()
 {
     this->levelCelView->createSubtile();
     this->updateWindow();
 }
 
-void MainWindow::on_actionClone_Subtile_triggered()
+void MainWindow::actionCloneSubtile_triggered()
 {
     this->levelCelView->cloneSubtile();
     this->updateWindow();
 }
 
-void MainWindow::on_actionInsert_Subtile_triggered()
+void MainWindow::actionInsertSubtile_triggered()
 {
     this->addSubtiles(false);
 }
 
-void MainWindow::on_actionAdd_Subtile_triggered()
+void MainWindow::actionAddSubtile_triggered()
 {
     this->addSubtiles(true);
 }
 
-void MainWindow::on_actionReplace_Subtile_triggered()
+void MainWindow::actionReplaceSubtile_triggered()
 {
     QString filter = imageNameFilter();
     QString imgFilePath = this->fileDialog(FILE_DIALOG_MODE::OPEN, "Replacement Image File", filter.toLatin1().data());
@@ -1148,35 +1148,35 @@ void MainWindow::on_actionReplace_Subtile_triggered()
     this->ui->statusBar->clearMessage();
 }
 
-void MainWindow::on_actionDel_Subtile_triggered()
+void MainWindow::actionDelSubtile_triggered()
 {
     this->levelCelView->removeCurrentSubtile();
     this->updateWindow();
 }
 
-void MainWindow::on_actionCreate_Tile_triggered()
+void MainWindow::actionCreateTile_triggered()
 {
     this->levelCelView->createTile();
     this->updateWindow();
 }
 
-void MainWindow::on_actionClone_Tile_triggered()
+void MainWindow::actionCloneTile_triggered()
 {
     this->levelCelView->cloneTile();
     this->updateWindow();
 }
 
-void MainWindow::on_actionInsert_Tile_triggered()
+void MainWindow::actionInsertTile_triggered()
 {
     this->addTiles(false);
 }
 
-void MainWindow::on_actionAdd_Tile_triggered()
+void MainWindow::actionAddTile_triggered()
 {
     this->addTiles(true);
 }
 
-void MainWindow::on_actionReplace_Tile_triggered()
+void MainWindow::actionReplaceTile_triggered()
 {
     QString filter = imageNameFilter();
     QString imgFilePath = this->fileDialog(FILE_DIALOG_MODE::OPEN, "Replacement Image File", filter.toLatin1().data());
@@ -1196,7 +1196,7 @@ void MainWindow::on_actionReplace_Tile_triggered()
     this->ui->statusBar->clearMessage();
 }
 
-void MainWindow::on_actionDel_Tile_triggered()
+void MainWindow::actionDelTile_triggered()
 {
     this->levelCelView->removeCurrentTile();
     this->updateWindow();

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -82,32 +82,32 @@ private:
     void addTiles(bool append);
 
 public slots:
-    void on_actionInsert_Frame_triggered();
-    void on_actionAdd_Frame_triggered();
-    void on_actionReplace_Frame_triggered();
-    void on_actionDel_Frame_triggered();
+    void actionInsertFrame_triggered();
+    void actionAddFrame_triggered();
+    void actionReplaceFrame_triggered();
+    void actionDelFrame_triggered();
 
-    void on_actionCreate_Subtile_triggered();
-    void on_actionInsert_Subtile_triggered();
-    void on_actionAdd_Subtile_triggered();
-    void on_actionReplace_Subtile_triggered();
-    void on_actionClone_Subtile_triggered();
-    void on_actionDel_Subtile_triggered();
+    void actionCreateSubtile_triggered();
+    void actionInsertSubtile_triggered();
+    void actionAddSubtile_triggered();
+    void actionReplaceSubtile_triggered();
+    void actionCloneSubtile_triggered();
+    void actionDelSubtile_triggered();
 
-    void on_actionCreate_Tile_triggered();
-    void on_actionClone_Tile_triggered();
-    void on_actionInsert_Tile_triggered();
-    void on_actionAdd_Tile_triggered();
-    void on_actionReplace_Tile_triggered();
-    void on_actionDel_Tile_triggered();
+    void actionCreateTile_triggered();
+    void actionCloneTile_triggered();
+    void actionInsertTile_triggered();
+    void actionAddTile_triggered();
+    void actionReplaceTile_triggered();
+    void actionDelTile_triggered();
 
     void buildRecentFilesMenu();
     void addRecentFile(QString filePath);
     void on_actionClear_History_triggered();
 
 private slots:
-    void on_actionNew_Sprite_triggered();
-    void on_actionNew_Tileset_triggered();
+    void actionNewSprite_triggered();
+    void actionNewTileset_triggered();
 
     void on_actionOpen_triggered();
     void on_actionOpenAs_triggered();

--- a/source/palettewidget.cpp
+++ b/source/palettewidget.cpp
@@ -505,12 +505,12 @@ void PaletteWidget::ShowContextMenu(const QPoint &pos)
     contextMenu.setToolTipsVisible(true);
 
     QAction action0("Undo", this);
-    QObject::connect(&action0, SIGNAL(triggered()), this, SLOT(on_actionUndo_triggered()));
+    QObject::connect(&action0, SIGNAL(triggered()), this, SLOT(actionUndo_triggered()));
     action0.setEnabled(this->undoStack->canUndo());
     contextMenu.addAction(&action0);
 
     QAction action1("Redo", this);
-    QObject::connect(&action1, SIGNAL(triggered()), this, SLOT(on_actionRedo_triggered()));
+    QObject::connect(&action1, SIGNAL(triggered()), this, SLOT(actionRedo_triggered()));
     action1.setEnabled(this->undoStack->canRedo());
     contextMenu.addAction(&action1);
 
@@ -801,12 +801,12 @@ void PaletteWidget::on_closePushButtonClicked()
     ((MainWindow *)this->window())->paletteWidget_callback(this, PWIDGET_CALLBACK_TYPE::PWIDGET_CALLBACK_CLOSE);
 }
 
-void PaletteWidget::on_actionUndo_triggered()
+void PaletteWidget::actionUndo_triggered()
 {
     this->undoStack->undo();
 }
 
-void PaletteWidget::on_actionRedo_triggered()
+void PaletteWidget::actionRedo_triggered()
 {
     this->undoStack->redo();
 }

--- a/source/palettewidget.h
+++ b/source/palettewidget.h
@@ -200,8 +200,8 @@ private slots:
     void on_saveAsPushButtonClicked();
     void on_closePushButtonClicked();
 
-    void on_actionUndo_triggered();
-    void on_actionRedo_triggered();
+    void actionUndo_triggered();
+    void actionRedo_triggered();
 
     void on_pathComboBox_activated(int index);
     void on_displayComboBox_activated(int index);


### PR DESCRIPTION
Currently whenever UI gets loaded and we try to connect a slot with a signal emitted in QAction, for example in appending frame, inserting it, etc. we get warnings like these:

`qt.core.qmetaobject.connectslotsbyname: QMetaObject::connectSlotsByName: No matching signal for on_actionAdd_Frame_triggered()`

This is because MOC tries to automatically connect functions which have "on_objectname_triggered" signature, and it can't find a matching signal for it by default. So the solution for that is to simply not use the autoconnection mechanism by changing names of those slots, removing "on" prefix from them - this way we won't get those warnings whenever we load certain parts of GUI.