### PR TITLE
Undostack: Introduce undostack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Widgets)
@@ -43,6 +43,10 @@ set(PROJECT_SOURCES
         source/openasdialog.cpp
         source/palettewidget.cpp
         source/settingsdialog.cpp
+        source/undostack.cpp
+        source/undostack.h
+        source/command.cpp
+        source/command.h
 )
 
 if(${QT_VERSION_MAJOR} GREATER_EQUAL 6)

--- a/source/celview.h
+++ b/source/celview.h
@@ -9,13 +9,13 @@
 #include <QPoint>
 #include <QStringList>
 #include <QTimer>
-#include <QUndoStack>
 #include <QWidget>
 
 #include <memory>
 #include <stack>
 
 #include "d1gfx.h"
+#include "undostack.h"
 
 #define CEL_SCENE_SPACING 8
 
@@ -50,7 +50,7 @@ class CelView : public QWidget {
     Q_OBJECT
 
 public:
-    explicit CelView(std::shared_ptr<QUndoStack> us, QWidget *parent = nullptr);
+    explicit CelView(std::shared_ptr<UndoStack> us, QWidget *parent = nullptr);
     ~CelView();
 
     void initialize(D1Gfx *gfx);
@@ -111,7 +111,7 @@ private:
     std::stack<int> removedGroupIdxs;      // holds indexes of groups that have been removed, used for undo ops
     std::stack<int> removedFrameGroupIdxs; // holds group indexes of frames that got removed, used for undo ops
 
-    std::shared_ptr<QUndoStack> undoStack;
+    std::shared_ptr<UndoStack> undoStack;
     Ui::CelView *ui;
     CelScene *celScene;
 

--- a/source/command.cpp
+++ b/source/command.cpp
@@ -1,10 +1,21 @@
 #include "command.h"
 
+/**
+ * @brief Sets if a command is obsolete or not
+ *
+ * This function sets if a command is obsolete or not.
+ * This flag will be used in UndoStack to check if a
+ * command should be popped whenever there will be undo/redo
+ * operation used, or user pushes any command onto the stack.
+ */
 void Command::setObsolete(bool isObsolete)
 {
     m_isObsolete = isObsolete;
 }
 
+/**
+ * @brief Returns if a command is obsolete or not
+ */
 bool Command::isObsolete() const
 {
     return m_isObsolete;

--- a/source/command.cpp
+++ b/source/command.cpp
@@ -1,0 +1,11 @@
+#include "command.h"
+
+void Command::setObsolete(bool isObsolete)
+{
+    m_isObsolete = isObsolete;
+}
+
+bool Command::isObsolete() const
+{
+    return m_isObsolete;
+}

--- a/source/command.h
+++ b/source/command.h
@@ -1,0 +1,15 @@
+#pragma once
+
+class Command {
+public:
+    virtual void undo() = 0;
+    virtual void redo() = 0;
+
+    void setObsolete(bool isObsolete);
+    bool isObsolete() const;
+
+    virtual ~Command() = default;
+
+private:
+    bool m_isObsolete = false;
+};

--- a/source/framecmds.cpp
+++ b/source/framecmds.cpp
@@ -5,7 +5,7 @@
 #include "framecmds.h"
 #include "mainwindow.h"
 
-RemoveFrameCommand::RemoveFrameCommand(int currentFrameIndex, const QImage img, QUndoCommand *parent)
+RemoveFrameCommand::RemoveFrameCommand(int currentFrameIndex, const QImage img)
     : frameIndexToRevert(currentFrameIndex)
     , imgToRevert(img)
 {
@@ -22,7 +22,7 @@ void RemoveFrameCommand::redo()
     emit this->removed(frameIndexToRevert);
 }
 
-ReplaceFrameCommand::ReplaceFrameCommand(int currentFrameIndex, const QImage imgToReplace, const QImage imgToRestore, QUndoCommand *parent)
+ReplaceFrameCommand::ReplaceFrameCommand(int currentFrameIndex, const QImage imgToReplace, const QImage imgToRestore)
     : frameIndexToReplace(currentFrameIndex)
     , imgToReplace(imgToReplace)
     , imgToRestore(imgToRestore)
@@ -40,7 +40,7 @@ void ReplaceFrameCommand::redo()
     emit this->replaced(frameIndexToReplace, imgToReplace);
 }
 
-AddFrameCommand::AddFrameCommand(IMAGE_FILE_MODE mode, int index, const QString imagefilePath, QUndoCommand *parent)
+AddFrameCommand::AddFrameCommand(IMAGE_FILE_MODE mode, int index, const QString imagefilePath)
     : startingIndex(index)
     , mode(mode)
 {

--- a/source/framecmds.h
+++ b/source/framecmds.h
@@ -1,14 +1,15 @@
 #pragma once
 
 #include "celview.h"
-#include <QObject>
-#include <QUndoCommand>
+#include "command.h"
 
-class RemoveFrameCommand : public QObject, public QUndoCommand {
+#include <QObject>
+
+class RemoveFrameCommand : public QObject, public Command {
     Q_OBJECT
 
 public:
-    explicit RemoveFrameCommand(int currentFrameIndex, const QImage img, QUndoCommand *parent = nullptr);
+    explicit RemoveFrameCommand(int currentFrameIndex, const QImage img);
     ~RemoveFrameCommand() = default;
 
     void undo() override;
@@ -23,11 +24,11 @@ private:
     int frameIndexToRevert = 0;
 };
 
-class ReplaceFrameCommand : public QObject, public QUndoCommand {
+class ReplaceFrameCommand : public QObject, public Command {
     Q_OBJECT
 
 public:
-    explicit ReplaceFrameCommand(int currentFrameIndex, const QImage imgToReplace, const QImage imgToRestore, QUndoCommand *parent = nullptr);
+    explicit ReplaceFrameCommand(int currentFrameIndex, const QImage imgToReplace, const QImage imgToRestore);
     ~ReplaceFrameCommand() = default;
 
     void undo() override;
@@ -43,11 +44,11 @@ private:
     int frameIndexToReplace = 0;
 };
 
-class AddFrameCommand : public QObject, public QUndoCommand {
+class AddFrameCommand : public QObject, public Command {
     Q_OBJECT
 
 public:
-    explicit AddFrameCommand(IMAGE_FILE_MODE mode, int index, const QString imagefilePath, QUndoCommand *parent = nullptr);
+    explicit AddFrameCommand(IMAGE_FILE_MODE mode, int index, const QString imagefilePath);
     ~AddFrameCommand() = default;
 
     void undo() override;

--- a/source/levelcelview.h
+++ b/source/levelcelview.h
@@ -9,7 +9,6 @@
 #include <QImage>
 #include <QPoint>
 #include <QTimer>
-#include <QUndoStack>
 #include <QWidget>
 
 #include <memory>
@@ -26,6 +25,7 @@
 #include "leveltabframewidget.h"
 #include "leveltabsubtilewidget.h"
 #include "leveltabtilewidget.h"
+#include "undostack.h"
 
 namespace Ui {
 class LevelCelView;
@@ -43,7 +43,7 @@ class LevelCelView : public QWidget {
     Q_OBJECT
 
 public:
-    explicit LevelCelView(std::shared_ptr<QUndoStack> us, QWidget *parent = nullptr);
+    explicit LevelCelView(std::shared_ptr<UndoStack> us, QWidget *parent = nullptr);
     ~LevelCelView();
 
     void initialize(D1Gfx *gfx, D1Min *min, D1Til *til, D1Sol *sol, D1Amp *amp);
@@ -160,7 +160,7 @@ private slots:
     void insertFrame(int index, QImage image);
 
 private:
-    std::shared_ptr<QUndoStack> undoStack;
+    std::shared_ptr<UndoStack> undoStack;
     Ui::LevelCelView *ui;
     CelScene *celScene;
     LevelTabTileWidget *tabTileWidget = new LevelTabTileWidget();

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -5,7 +5,6 @@
 #include <QMimeData>
 #include <QString>
 #include <QStringList>
-#include <QUndoCommand>
 
 #include <memory>
 
@@ -22,6 +21,7 @@
 #include "openasdialog.h"
 #include "palettewidget.h"
 #include "settingsdialog.h"
+#include <undostack.h>
 
 #define D1_GRAPHICS_TOOL_TITLE "Diablo 1 Graphics Tool"
 #define D1_GRAPHICS_TOOL_VERSION "1.0.1"
@@ -84,6 +84,9 @@ private:
     void addTiles(bool append);
 
 public slots:
+    void actionUndo_triggered();
+    void actionRedo_triggered();
+
     void actionInsertFrame_triggered();
     void actionAddFrame_triggered();
     void actionReplaceFrame_triggered();
@@ -166,7 +169,7 @@ private:
     QMenu subtileMenu = QMenu("Tile");
     QMenu tileMenu = QMenu("MegaTile");
 
-    std::shared_ptr<QUndoStack> undoStack;
+    std::shared_ptr<UndoStack> undoStack;
     QAction *undoAction;
     QAction *redoAction;
 

--- a/source/palettewidget.h
+++ b/source/palettewidget.h
@@ -6,8 +6,6 @@
 #include <QGraphicsScene>
 #include <QMouseEvent>
 #include <QStyle>
-#include <QUndoCommand>
-#include <QUndoStack>
 #include <QWidget>
 
 #include "celview.h"
@@ -15,6 +13,7 @@
 #include "d1palhits.h"
 #include "d1trn.h"
 #include "levelcelview.h"
+#include "undostack.h"
 
 #define PALETTE_WIDTH 192
 #define PALETTE_COLORS_PER_LINE 16
@@ -36,11 +35,11 @@ class EditColorsCommand;
 class EditTranslationsCommand;
 } // namespace Ui
 
-class EditColorsCommand : public QObject, public QUndoCommand {
+class EditColorsCommand : public QObject, public Command {
     Q_OBJECT
 
 public:
-    explicit EditColorsCommand(D1Pal *, quint8, quint8, QColor, QColor, QUndoCommand *parent = nullptr);
+    explicit EditColorsCommand(D1Pal *, quint8, quint8, QColor, QColor);
     ~EditColorsCommand() = default;
 
     void undo() override;
@@ -58,11 +57,11 @@ private:
     QColor endColor;
 };
 
-class EditTranslationsCommand : public QObject, public QUndoCommand {
+class EditTranslationsCommand : public QObject, public Command {
     Q_OBJECT
 
 public:
-    explicit EditTranslationsCommand(D1Trn *, quint8, quint8, QList<quint8>, QUndoCommand *parent = nullptr);
+    explicit EditTranslationsCommand(D1Trn *, quint8, quint8, QList<quint8>);
     ~EditTranslationsCommand() = default;
 
     void undo() override;
@@ -79,11 +78,11 @@ private:
     QList<quint8> newTranslations;
 };
 
-class ClearTranslationsCommand : public QObject, public QUndoCommand {
+class ClearTranslationsCommand : public QObject, public Command {
     Q_OBJECT
 
 public:
-    explicit ClearTranslationsCommand(D1Trn *, quint8, quint8, QUndoCommand *parent = nullptr);
+    explicit ClearTranslationsCommand(D1Trn *, quint8, quint8);
     ~ClearTranslationsCommand() = default;
 
     void undo() override;
@@ -125,7 +124,7 @@ class PaletteWidget : public QWidget {
     Q_OBJECT
 
 public:
-    explicit PaletteWidget(std::shared_ptr<QUndoStack> undoStack, QString title);
+    explicit PaletteWidget(std::shared_ptr<UndoStack> undoStack, QString title);
     ~PaletteWidget();
 
     void setPal(D1Pal *p);
@@ -216,7 +215,7 @@ private slots:
     void on_monsterTrnPushButton_clicked();
 
 private:
-    std::shared_ptr<QUndoStack> undoStack;
+    std::shared_ptr<UndoStack> undoStack;
     Ui::PaletteWidget *ui;
     bool isTrn;
 

--- a/source/undostack.cpp
+++ b/source/undostack.cpp
@@ -1,5 +1,13 @@
 #include "undostack.h"
 
+/**
+ * @brief Pushes new commands onto the commands stack (Undostack)
+ *
+ * This function pushes new commands onto the undo stack, and redos
+ * the command that got currently pushed, essentially triggering the command.
+ * It also erases any commands that had isObsolete flag set.
+ * Push also removes any commands that were currently undo'd on the stack.
+ */
 void UndoStack::push(std::unique_ptr<Command> cmd)
 {
     try {
@@ -24,6 +32,13 @@ void UndoStack::push(std::unique_ptr<Command> cmd)
     m_undoPos = m_cmds.size() - 1;
 }
 
+/**
+ * @brief Undos command that is currently the first one on the stack
+ *
+ * This function undos the command that is currently on the stack, setting
+ * redo option to be available at the same time. It also pops any commands that
+ * have the isObsolete flag set.
+ */
 void UndoStack::undo()
 {
     // Erase any command that was previously set as obsolete
@@ -38,6 +53,13 @@ void UndoStack::undo()
     m_undoPos--;
 }
 
+/**
+ * @brief Redos command that is currently the first one on the stack
+ *
+ * This function redos the command that is currently on the stack, setting
+ * undo option to be available at the same time. It also pops any commands that
+ * have the isObsolete flag set.
+ */
 void UndoStack::redo()
 {
     // erase any command that was previously set as obsolete
@@ -52,16 +74,29 @@ void UndoStack::redo()
         m_canRedo = false;
 }
 
+/**
+ * @brief Returns if stack can currently redo
+ */
 bool UndoStack::canRedo() const
 {
     return m_canRedo;
 }
 
+/**
+ * @brief Returns if stack can currently undo
+ */
 bool UndoStack::canUndo() const
 {
     return m_canUndo;
 }
 
+/**
+ * @brief Sets undo stack to a starting position
+ *
+ * This function clears undo stack to a starting position. To be
+ * exact it sets it's position to 0, clears any commands and disables
+ * flags that inform if stack can currently undo or redo.
+ */
 void UndoStack::clear()
 {
     m_undoPos = 0;

--- a/source/undostack.cpp
+++ b/source/undostack.cpp
@@ -1,0 +1,70 @@
+#include "undostack.h"
+
+void UndoStack::push(std::unique_ptr<Command> cmd)
+{
+    try {
+        cmd->redo();
+    } catch (...) {
+        /* TODO: here we we will start to implement proper
+         * exception handling, but first we need to implement stuff
+         * that will use it
+         */
+    }
+
+    // Erase any command that was set to obsolete
+    std::erase_if(m_cmds, [](const auto &cmd) { return cmd->isObsolete(); });
+
+    // Drop any command that's after currently undo'd index
+    if (m_cmds.begin() + (m_undoPos + 1) <= m_cmds.end())
+        m_cmds.erase(m_cmds.begin() + (m_undoPos + 1), m_cmds.end());
+
+    m_cmds.push_back(std::move(cmd));
+    m_canUndo = true;
+    m_canRedo = false;
+    m_undoPos = m_cmds.size() - 1;
+}
+
+void UndoStack::undo()
+{
+    // Erase any command that was previously set as obsolete
+    std::erase_if(m_cmds, [](const auto &cmd) { return cmd->isObsolete(); });
+
+    if (m_undoPos == 0)
+        m_canUndo = false;
+
+    m_cmds[m_undoPos]->undo();
+
+    m_canRedo = true;
+    m_undoPos--;
+}
+
+void UndoStack::redo()
+{
+    // erase any command that was previously set as obsolete
+    std::erase_if(m_cmds, [](const auto &cmd) { return cmd->isObsolete(); });
+
+    m_cmds[m_undoPos + 1]->redo();
+
+    m_undoPos++;
+    m_canUndo = true;
+
+    if (m_undoPos + 1 > m_cmds.size() - 1)
+        m_canRedo = false;
+}
+
+bool UndoStack::canRedo() const
+{
+    return m_canRedo;
+}
+
+bool UndoStack::canUndo() const
+{
+    return m_canUndo;
+}
+
+void UndoStack::clear()
+{
+    m_undoPos = 0;
+    m_canUndo = m_canRedo = false;
+    m_cmds.clear();
+}

--- a/source/undostack.h
+++ b/source/undostack.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "command.h"
+
+#include <array>
+#include <memory>
+#include <vector>
+
+class UndoStack {
+public:
+    UndoStack() = default;
+    ~UndoStack() = default;
+
+    void push(std::unique_ptr<Command> cmd);
+
+    void undo();
+    void redo();
+    [[nodiscard]] bool canUndo() const;
+    [[nodiscard]] bool canRedo() const;
+
+    void clear();
+
+private:
+    bool m_canUndo = false;
+    bool m_canRedo = false;
+    int8_t m_undoPos = 0;
+    std::vector<std::unique_ptr<Command>> m_cmds; // holds all the commands on the stack
+};


### PR DESCRIPTION
Right now we're using QUndoStack which is from Qt library, although it has limited usage which we want to expand since we want to handle errors in a proper way without any hacks regarding QUndoStack, so these series of patches will introduce customly made Undostack, as well as Command class which will replace QUndoCommand/QUndoStack classes.