### PR TITLE
QActions: Rename QActions of Add <X> to Append <X>

### DIFF
--- a/source/celview.cpp
+++ b/source/celview.cpp
@@ -394,7 +394,7 @@ void CelView::ShowContextMenu(const QPoint &pos)
     QObject::connect(&action0, SIGNAL(triggered()), mw, SLOT(actionInsertFrame_triggered()));
     contextMenu.addAction(&action0);
 
-    QAction action1("Add Frame", this);
+    QAction action1("Append Frame", this);
     action1.setToolTip("Add new frames at the end");
     QObject::connect(&action1, SIGNAL(triggered()), mw, SLOT(actionAddFrame_triggered()));
     contextMenu.addAction(&action1);

--- a/source/levelcelview.cpp
+++ b/source/levelcelview.cpp
@@ -1586,7 +1586,7 @@ void LevelCelView::ShowContextMenu(const QPoint &pos)
     QObject::connect(&action0, SIGNAL(triggered()), mw, SLOT(actionInsertFrame_triggered()));
     frameMenu.addAction(&action0);
 
-    QAction action1("Add", this);
+    QAction action1("Append", this);
     action1.setToolTip("Add new frames at the end");
     QObject::connect(&action1, SIGNAL(triggered()), mw, SLOT(actionAddFrame_triggered()));
     frameMenu.addAction(&action1);
@@ -1622,7 +1622,7 @@ void LevelCelView::ShowContextMenu(const QPoint &pos)
     QObject::connect(&action5, SIGNAL(triggered()), mw, SLOT(actionInsertSubtile_triggered()));
     subtileMenu.addAction(&action5);
 
-    QAction action6("Add", this);
+    QAction action6("Append", this);
     action6.setToolTip("Add new subtiles at the end");
     QObject::connect(&action6, SIGNAL(triggered()), mw, SLOT(actionAddSubtile_triggered()));
     subtileMenu.addAction(&action6);
@@ -1661,7 +1661,7 @@ void LevelCelView::ShowContextMenu(const QPoint &pos)
     QObject::connect(&action10, SIGNAL(triggered()), mw, SLOT(actionInsertTile_triggered()));
     tileMenu.addAction(&action10);
 
-    QAction action11("Add", this);
+    QAction action11("Append", this);
     action11.setToolTip("Add new tiles at the end");
     QObject::connect(&action11, SIGNAL(triggered()), mw, SLOT(actionAddTile_triggered()));
     tileMenu.addAction(&action11);

--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -63,7 +63,7 @@ MainWindow::MainWindow()
     // Initialize 'Frame' submenu of 'Edit'
     this->frameMenu.setToolTipsVisible(true);
     this->frameMenu.addAction("Insert", this, SLOT(actionInsertFrame_triggered()))->setToolTip("Add new frames before the current one");
-    this->frameMenu.addAction("Add", this, SLOT(actionAddFrame_triggered()))->setToolTip("Add new frames at the end");
+    this->frameMenu.addAction("Append", this, SLOT(actionAddFrame_triggered()))->setToolTip("Add new frames at the end");
     this->frameMenu.addAction("Replace", this, SLOT(actionReplaceFrame_triggered()))->setToolTip("Replace the current frame");
     this->frameMenu.addAction("Delete", this, SLOT(actionDelFrame_triggered()))->setToolTip("Delete the current frame");
     this->ui->menuEdit->addMenu(&this->frameMenu);
@@ -72,7 +72,7 @@ MainWindow::MainWindow()
     this->subtileMenu.setToolTipsVisible(true);
     this->subtileMenu.addAction("Create", this, SLOT(actionCreateSubtile_triggered()))->setToolTip("Create a new tile");
     this->subtileMenu.addAction("Insert", this, SLOT(actionInsertSubtile_triggered()))->setToolTip("Add new tiles before the current one");
-    this->subtileMenu.addAction("Add", this, SLOT(actionAddSubtile_triggered()))->setToolTip("Add new tiles at the end");
+    this->subtileMenu.addAction("Append", this, SLOT(actionAddSubtile_triggered()))->setToolTip("Add new tiles at the end");
     this->subtileMenu.addAction("Clone", this, SLOT(actionCloneSubtile_triggered()))->setToolTip("Add new tiles at the end based on the current one");
     this->subtileMenu.addAction("Replace", this, SLOT(actionReplaceSubtile_triggered()))->setToolTip("Replace the current tile");
     this->subtileMenu.addAction("Delete", this, SLOT(actionDelSubtile_triggered()))->setToolTip("Delete the current tile");
@@ -82,7 +82,7 @@ MainWindow::MainWindow()
     this->tileMenu.setToolTipsVisible(true);
     this->tileMenu.addAction("Create", this, SLOT(actionCreateTile_triggered()))->setToolTip("Create a new megatile");
     this->tileMenu.addAction("Insert", this, SLOT(actionInsertTile_triggered()))->setToolTip("Add new megatiles before the current one");
-    this->tileMenu.addAction("Add", this, SLOT(actionAddTile_triggered()))->setToolTip("Add new megatiles at the end");
+    this->tileMenu.addAction("Append", this, SLOT(actionAddTile_triggered()))->setToolTip("Add new megatiles at the end");
     this->tileMenu.addAction("Clone", this, SLOT(actionCloneTile_triggered()))->setToolTip("Add new megatile at the end based on the current one");
     this->tileMenu.addAction("Replace", this, SLOT(actionReplaceTile_triggered()))->setToolTip("Replace the current megatile");
     this->tileMenu.addAction("Delete", this, SLOT(actionDelTile_triggered()))->setToolTip("Delete the current megatile");


### PR DESCRIPTION
Those patches rename all QActions instances in MainWindow/CelView/LevelCelView from Add Frame to Append  Frame, this way it's more clearer for the user, since "Insert" option is already adding frames, "Add" right now seems to be too ambiguous.

Resolves: https://github.com/diasurgical/d1-graphics-tool/issues/131