### PR TITLE
Undostack: Fix segfault when trying to fetch macro on -1 index

### DIFF
--- a/source/undostack/undostack.cpp
+++ b/source/undostack/undostack.cpp
@@ -184,6 +184,13 @@ void UndoStack::addMacro(UndoMacroFactory &macroFactory)
  */
 void UndoStack::eraseRedundantCmds()
 {
+    // If user has undo'd all the commands, then erase everything
+    if (m_undoPos < 0) {
+        m_cmds.clear();
+        m_macros.clear();
+        return;
+    }
+
     // Erase any command that was set to obsolete
     std::erase_if(m_cmds, [](const auto &cmd) { return cmd->isObsolete(); });
 


### PR DESCRIPTION
Currently, if user adds a command to the undostack, and then undos it, and then adds another command - this causes a segfault while fetching macro ID from command on current undoPos. Current undo position pointer of undostack is being moved to -1 if user undos every possible command on the stack. Everytime user adds a new command, eraseRedundantCmds() method is being called, because all commands that are in "undo" state need to be cleared. So the solution to that is to simply clear every single macro and command while erasing redundant commands, if the current undo position is -1 - this basically means that every single command/macro is in undo state, so we clear all of them.

As a reproduction with and without this patch:
1. open CelView
2. insert/delete/replace a frame
3. undo this operation
4. once again do some operation on frames
5. Expected: last command which was undo'd gets removed, new command gets pushed and we see a result of this command, actual result: segfault happens (with this patch it doesn't)