### PR TITLE
Everywhere: Add coordinates of current cursor position to QStatusBar

### DIFF
--- a/source/mainwindow.cpp
+++ b/source/mainwindow.cpp
@@ -625,7 +625,7 @@ void MainWindow::openFile(const OpenAsParam &params)
     QObject::connect(this->trnUniqueWidget, &PaletteWidget::clearRootBorder, this->trnWidget, &PaletteWidget::clearBorder);
 
     if (isTileset) {
-        this->levelCelView = new LevelCelView(this->undoStack);
+        this->levelCelView = new LevelCelView(this->undoStack, this);
         this->levelCelView->initialize(this->gfx, this->min, this->til, this->sol, this->amp);
 
         // Refresh CEL view if a PAL or TRN is modified
@@ -651,7 +651,7 @@ void MainWindow::openFile(const OpenAsParam &params)
     }
     // Otherwise build a CelView
     else {
-        this->celView = new CelView(this->undoStack);
+        this->celView = new CelView(this->undoStack, this);
         this->celView->initialize(this->gfx);
 
         // Refresh CEL view if a PAL or TRN is modified
@@ -776,6 +776,12 @@ void MainWindow::openPalFiles(QStringList filePaths, PaletteWidget *widget)
 
     // Clear loading message from status bar
     this->ui->statusBar->clearMessage();
+}
+
+void MainWindow::updateStatusBar(const QString &status, const QString &styleSheet)
+{
+    this->ui->statusBar->setStyleSheet(styleSheet);
+    this->ui->statusBar->showMessage(status);
 }
 
 void MainWindow::saveFile(const QString &gfxPath)

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -63,6 +63,7 @@ public:
 
     void nextPaletteCycle(D1PAL_CYCLE_TYPE type);
     void resetPaletteCycle();
+    void updateStatusBar(const QString &status, const QString &styleSheet);
 
     QString getLastFilePath();
     QString fileDialog(FILE_DIALOG_MODE mode, const char *title, const char *filter);

--- a/source/views/celview.h
+++ b/source/views/celview.h
@@ -33,6 +33,7 @@ public:
 
 private slots:
     void mousePressEvent(QGraphicsSceneMouseEvent *event);
+    void mouseMoveEvent(QGraphicsSceneMouseEvent *event);
     void dragEnterEvent(QGraphicsSceneDragDropEvent *event);
     void dragMoveEvent(QGraphicsSceneDragDropEvent *event);
     void dropEvent(QGraphicsSceneDragDropEvent *event);
@@ -66,6 +67,7 @@ public:
     void updateGroupIndex();
 
     void displayFrame();
+    [[nodiscard]] bool isInImage(unsigned int x, unsigned int y) const;
 
 signals:
     void frameRefreshed();

--- a/source/views/levelcelview.cpp
+++ b/source/views/levelcelview.cpp
@@ -184,6 +184,13 @@ void LevelCelView::update()
     this->tabFrameWidget->initialize(this, this->gfx);
 }
 
+/**
+ * @brief Checks in which image type the coordinates are currently in
+ *
+ * This function accepts coordinates and checks, based on them in which
+ * image type (frame, tile or megatile), the coordinates are currently in.
+ * This is currently useful for knowing where exactly user's cursor is.
+ */
 IMAGE_TYPE LevelCelView::checkImageType(unsigned x, unsigned y)
 {
     unsigned celFrameWidth = MICRO_WIDTH; // this->gfx->getFrameWidth(this->currentFrameIndex);

--- a/source/views/levelcelview.h
+++ b/source/views/levelcelview.h
@@ -39,6 +39,13 @@ enum class TILESET_MODE {
     TILE,    // Edit tile
 };
 
+enum class IMAGE_TYPE {
+    NONE,
+    FRAME,
+    SUBTILE,
+    TILE
+};
+
 class LevelCelView : public QWidget {
     Q_OBJECT
 
@@ -93,6 +100,8 @@ public:
     void sortSubtiles();
 
     void displayFrame();
+
+    IMAGE_TYPE checkImageType(unsigned int x, unsigned int y);
 
 private:
     void update();

--- a/source/views/view.cpp
+++ b/source/views/view.cpp
@@ -1,8 +1,10 @@
 #include "view.h"
+#include "mainwindow.h"
 
 View::View(QWidget *parent)
     : QGraphicsView(parent)
 {
+    this->setMouseTracking(true);
 }
 
 void View::mousePressEvent(QMouseEvent *event)
@@ -49,4 +51,9 @@ void View::mouseReleaseEvent(QMouseEvent *event)
         break;
     }
     }
+}
+
+void View::leaveEvent(QEvent *event)
+{
+    dynamic_cast<MainWindow *>(this->window())->updateStatusBar("", "color: rgb(0, 0, 0);");
 }

--- a/source/views/view.h
+++ b/source/views/view.h
@@ -13,4 +13,5 @@ public:
 private slots:
     void mouseReleaseEvent(QMouseEvent *event);
     void mousePressEvent(QMouseEvent *event);
+    void leaveEvent(QEvent *event) override;
 };


### PR DESCRIPTION
This patch adds coordinates of current cursor position to QStatusBar while displaying them in two different colors either cursor is on an image or it is not.