### PR TITLE
Add support for empty CEL frames

### DIFF
--- a/source/d1formats/d1cl2.cpp
+++ b/source/d1formats/d1cl2.cpp
@@ -3,6 +3,7 @@
 #include <QBuffer>
 #include <QByteArray>
 #include <QDataStream>
+#include <QDebug>
 #include <QList>
 #include <QMessageBox>
 
@@ -263,8 +264,8 @@ bool D1Cl2::load(D1Gfx &gfx, QString filePath, bool isClx, const OpenAsParam &pa
 
         D1GfxFrame frame;
         if (!D1Cl2Frame::load(frame, cl2FrameRawData, isClx, params)) {
-            // TODO: log + add placeholder?
-            continue;
+            qDebug() << "Failed to load frame: " << gfx.frames.count();
+            frame = {};
         }
         gfx.frames.append(frame);
     }

--- a/source/d1formats/d1gfx.cpp
+++ b/source/d1formats/d1gfx.cpp
@@ -1,5 +1,32 @@
 #include "d1gfx.h"
+
+#include <QPainter>
+
 #include "d1image.h"
+
+namespace {
+
+QImage EmptyFramePlaceholder(QString text)
+{
+    QFont font("", 16);
+    QFontMetrics metrics = QFontMetrics(font);
+    QSize size = metrics.size(0, text);
+
+    QImage placeholder = QImage(
+        size.width(),
+        size.height(),
+        QImage::Format_ARGB32);
+
+    placeholder.fill(qRgba(0, 0, 0, 0));
+
+    QPainter painter = QPainter(&placeholder);
+    painter.setPen(Qt::gray);
+    painter.setFont(font);
+    painter.drawText(0, metrics.ascent(), text);
+    return placeholder;
+}
+
+} // namespace
 
 D1GfxPixel D1GfxPixel::transparentPixel()
 {
@@ -63,10 +90,16 @@ void D1GfxFrame::setFrameType(D1CEL_FRAME_TYPE type)
 // builds QImage from a D1CelFrame of given index
 QImage D1Gfx::getFrameImage(quint16 frameIndex)
 {
-    if (this->palette == nullptr || frameIndex >= this->frames.count())
-        return QImage();
+    if (this->palette == nullptr)
+        return EmptyFramePlaceholder("No palette");
+
+    if (frameIndex >= this->frames.count())
+        return EmptyFramePlaceholder("Out of bounds");
 
     D1GfxFrame &frame = this->frames[frameIndex];
+
+    if (frame.getWidth() == 0 || frame.getHeight() == 0)
+        return EmptyFramePlaceholder("No frame data");
 
     QImage image = QImage(
         frame.getWidth(),

--- a/source/views/celview.cpp
+++ b/source/views/celview.cpp
@@ -356,10 +356,8 @@ void CelView::displayFrame()
 
     // Getting the current frame to display
     QImage celFrame = this->gfx->getFrameImage(this->currentFrameIndex);
-
-    // Building a gray background of the width/height of the CEL frame
-    QImage celFrameBackground = QImage(celFrame.width(), celFrame.height(), QImage::Format_ARGB32);
-    celFrameBackground.fill(Qt::gray);
+    int celFrameWidth = this->gfx->getFrameWidth(this->currentFrameIndex);
+    int celFrameHeight = this->gfx->getFrameHeight(this->currentFrameIndex);
 
     // Resize the scene rectangle to include some padding around the CEL frame
     this->celScene->setSceneRect(0, 0,
@@ -368,15 +366,23 @@ void CelView::displayFrame()
     // ui->celGraphicsView->adjustSize();
     // ui->celFrameWidget->adjustSize();
 
-    // Add the backgrond and CEL frame while aligning it in the center
-    this->celScene->addPixmap(QPixmap::fromImage(celFrameBackground))
-        ->setPos(CEL_SCENE_SPACING, CEL_SCENE_SPACING);
+    if (celFrameWidth > 0 && celFrameHeight > 0) {
+        // Building a gray background of the width/height of the CEL frame
+        QImage celFrameBackground = QImage(celFrame.width(), celFrame.height(), QImage::Format_ARGB32);
+        celFrameBackground.fill(Qt::gray);
+
+        // Add the background behind the CEL frame
+        this->celScene->addPixmap(QPixmap::fromImage(celFrameBackground))
+            ->setPos(CEL_SCENE_SPACING, CEL_SCENE_SPACING);
+    }
+
+    // Add the CEL frame while aligning it in the center
     this->celScene->addPixmap(QPixmap::fromImage(celFrame))
         ->setPos(CEL_SCENE_SPACING, CEL_SCENE_SPACING);
 
     // Set current frame width and height
-    this->ui->celFrameWidthEdit->setText(QString::number(celFrame.width()) + " px");
-    this->ui->celFrameHeightEdit->setText(QString::number(celFrame.height()) + " px");
+    this->ui->celFrameWidthEdit->setText(QString::number(celFrameWidth) + " px");
+    this->ui->celFrameHeightEdit->setText(QString::number(celFrameHeight) + " px");
 
     // Set current group text
     this->ui->groupIndexEdit->setText(


### PR DESCRIPTION
This PR adds support for files with empty CEL frames, such as those used for non-printable characters in font sprite sheets.

Prior to this change, it would appear to the user that the empty frames simply do not exist. Furthermore, attempting to save the file would result in an error that crashes the application.

Here is how the empty frames look now:
![image](https://github.com/user-attachments/assets/ba9a2513-7724-4386-8cff-7ea07c96935c)