### PR TITLE
Add support for importing symbols from fonts as a spritesheet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ set(PROJECT_SOURCES
         source/d1formats/d1til.cpp
         source/d1formats/d1trn.cpp
         source/dialogs/exportdialog.cpp
+        source/dialogs/importdialog.cpp
         source/views/view.cpp
         source/views/levelcelview.cpp
         source/widgets/leveltabframewidget.cpp

--- a/source/dialogs/importdialog.cpp
+++ b/source/dialogs/importdialog.cpp
@@ -1,0 +1,120 @@
+#include "importdialog.h"
+
+#include <QColorDialog>
+#include <QFileDialog>
+#include <QFontDatabase>
+#include <QImageWriter>
+#include <QMessageBox>
+#include <QPainter>
+#include <algorithm>
+
+#include "mainwindow.h"
+#include "ui_importdialog.h"
+
+ImportDialog::ImportDialog(QWidget *parent)
+    : QDialog(parent)
+    , ui(new Ui::ImportDialog())
+{
+    ui->setupUi(this);
+}
+
+ImportDialog::~ImportDialog()
+{
+    delete ui;
+}
+
+void ImportDialog::initialize()
+{
+    // - remember the last selected type
+    QComboBox *typeBox = this->ui->typeComboBox;
+    QString lastFmt = typeBox->currentText();
+    if (lastFmt.isEmpty()) {
+        lastFmt = "Font";
+    }
+    typeBox->clear();
+    typeBox->addItem("Font");
+    typeBox->setCurrentIndex(typeBox->findText(lastFmt));
+
+    setRenderColor(this->renderColor);
+}
+
+void ImportDialog::setRenderColor(QColor color)
+{
+    QString red = QString::number(color.red());
+    QString green = QString::number(color.green());
+    QString blue = QString::number(color.blue());
+    QString styleSheet = QString("background: rgb(") + red + QString(",") + green + QString(",") + blue + QString(")");
+    ui->fontColorButton->setStyleSheet(styleSheet);
+    this->renderColor = color;
+}
+
+QString ImportDialog::getFileFormatExtension()
+{
+    return "." + this->ui->typeComboBox->currentText().toLower();
+}
+
+void ImportDialog::on_inputFileBrowseButton_clicked()
+{
+    QString selectedDirectory = QFileDialog::getOpenFileName(
+        this, "Select Font File", QString(), "Fonts (*.ttf *.otf)");
+
+    if (selectedDirectory.isEmpty())
+        return;
+
+    ui->inputFileEdit->setText(selectedDirectory);
+}
+
+void ImportDialog::on_fontSymbolsEdit_textChanged(const QString &text)
+{
+    bool ok = false;
+    uint test = text.toUInt(&ok, 16);
+    if (!ok) {
+        ui->fontSymbolsRangeLabel->setText("Error");
+        return;
+    }
+
+    QString pad = text.toLower();
+    while (pad.size() < 2)
+        pad = "0" + pad;
+
+    QString start = "U+" + pad + "00";
+    QString end = "U+" + pad + "ff";
+    ui->fontSymbolsRangeLabel->setText(start + " - " + end);
+}
+
+void ImportDialog::on_fontColorButton_clicked()
+{
+    QColor color = QColorDialog::getColor();
+    setRenderColor(color);
+}
+
+void ImportDialog::on_importButton_clicked()
+{
+    if (ui->inputFileEdit->text() == "") {
+        QMessageBox::warning(this, "Warning", "Input file is missing, please choose an input folder.");
+        return;
+    }
+
+    try {
+        MainWindow *mainWindow = dynamic_cast<MainWindow *>(this->parent());
+        if (mainWindow == nullptr) {
+            QMessageBox::critical(this, "Error", "Window not found.");
+            return;
+        }
+
+        QString filePath = ui->inputFileEdit->text();
+        int pointSize = ui->fontSizeEdit->text().toInt();
+        uint symbolPrefix = ui->fontSymbolsEdit->text().toUInt() << 8;
+        mainWindow->openFontFile(filePath, this->renderColor, pointSize, symbolPrefix);
+    } catch (...) {
+        QMessageBox::critical(this, "Error", "Import Failed.");
+        return;
+    }
+
+    this->close();
+}
+
+void ImportDialog::on_importCancelButton_clicked()
+{
+    this->close();
+}

--- a/source/dialogs/importdialog.h
+++ b/source/dialogs/importdialog.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <QDialog>
+#include <QProgressDialog>
+
+#include "d1formats/d1amp.h"
+#include "d1formats/d1gfx.h"
+#include "d1formats/d1min.h"
+#include "d1formats/d1sol.h"
+#include "d1formats/d1til.h"
+
+namespace Ui {
+class ImportDialog;
+}
+
+// subtiles per line if the output is groupped, an odd number to ensure it is not recognized as a flat tile
+#define EXPORT_SUBTILES_PER_LINE 15
+
+// frames per line if the output of a tileset-frames is groupped, an odd number to ensure it is not recognized as a flat tile or as subtiles
+#define EXPORT_LVLFRAMES_PER_LINE 31
+
+class ImportDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit ImportDialog(QWidget *parent = nullptr);
+    ~ImportDialog();
+
+    void initialize();
+
+private slots:
+    void on_inputFileBrowseButton_clicked();
+    void on_fontSymbolsEdit_textChanged(const QString &text);
+    void on_fontColorButton_clicked();
+    void on_importButton_clicked();
+    void on_importCancelButton_clicked();
+
+private:
+    void setRenderColor(QColor color);
+    QString getFileFormatExtension();
+
+    Ui::ImportDialog *ui;
+    QColor renderColor = QColor::fromRgb(204, 183, 117);
+};

--- a/source/dialogs/importdialog.ui
+++ b/source/dialogs/importdialog.ui
@@ -1,0 +1,381 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ImportDialog</class>
+ <widget class="QDialog" name="ImportDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>797</width>
+    <height>369</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Import</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="inputFileGroupBox">
+     <property name="title">
+      <string>Input File</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_0">
+      <item>
+       <widget class="QLineEdit" name="inputFileEdit">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="inputFileBrowseButton">
+        <property name="text">
+         <string>Browse</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="inputFileSettingsGroupBox">
+     <property name="title">
+      <string>Input File Settings</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="inputFileTypeLabel">
+        <property name="text">
+         <string>Import as:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="typeComboBox"/>
+      </item>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer1">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="2">
+       <spacer name="horizontalSpacer2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="fontRenderGroupBox">
+     <property name="title">
+      <string>Font Render Settings</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="fontSymbolsLabel">
+        <property name="text">
+         <string>Symbols:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QWidget" name="fontSymbolsFieldWidget" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>170</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>170</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="spacing">
+          <number>4</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLineEdit" name="fontSymbolsEdit">
+           <property name="minimumSize">
+            <size>
+             <width>50</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>50</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>0</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="fontSymbolsRangeLabel">
+           <property name="minimumSize">
+            <size>
+             <width>120</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>120</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>U+0000 - U+00ff</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="fontSizeLabel">
+        <property name="text">
+         <string>Size:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QWidget" name="fontSizeFieldWidget" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>50</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>50</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <property name="spacing">
+          <number>4</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLineEdit" name="fontSizeEdit">
+           <property name="minimumSize">
+            <size>
+             <width>50</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>50</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>12</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <spacer name="horizontalSpacer4">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="fontColorLabel">
+        <property name="text">
+         <string>Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QWidget" name="fontColorFieldWidget" native="true">
+        <property name="minimumSize">
+         <size>
+          <width>30</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>30</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_4">
+         <property name="spacing">
+          <number>4</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QPushButton" name="fontColorButton">
+           <property name="minimumSize">
+            <size>
+             <width>30</width>
+             <height>15</height>
+            </size>
+           </property>
+           <property name="maximumSize">
+            <size>
+             <width>30</width>
+             <height>15</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <spacer name="horizontalSpacer5">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="exportButtonsWidget" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_5">
+      <property name="spacing">
+       <number>4</number>
+      </property>
+      <property name="leftMargin">
+       <number>4</number>
+      </property>
+      <property name="topMargin">
+       <number>4</number>
+      </property>
+      <property name="rightMargin">
+       <number>4</number>
+      </property>
+      <property name="bottomMargin">
+       <number>4</number>
+      </property>
+      <item>
+       <spacer name="horizontalSpacer6">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="importButton">
+        <property name="text">
+         <string>Import</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="importCancelButton">
+        <property name="text">
+         <string>Cancel</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/source/mainwindow.h
+++ b/source/mainwindow.h
@@ -14,6 +14,7 @@
 #include "d1formats/d1til.h"
 #include "d1formats/d1trn.h"
 #include "dialogs/exportdialog.h"
+#include "dialogs/importdialog.h"
 #include "dialogs/openasdialog.h"
 #include "dialogs/settingsdialog.h"
 #include "palette/d1pal.h"
@@ -57,6 +58,7 @@ public:
     void openFile(const OpenAsParam &params);
     void openImageFiles(IMAGE_FILE_MODE mode, QStringList filePaths, bool append);
     void openPalFiles(QStringList filePaths, PaletteWidget *widget);
+    void openFontFile(QString filePath, QColor renderColor, int pointSize, uint symbolPrefix);
     void saveFile(const QString &gfxPath);
 
     void paletteWidget_callback(PaletteWidget *widget, PWIDGET_CALLBACK_TYPE type);
@@ -121,6 +123,7 @@ private slots:
 
     void on_actionOpen_triggered();
     void on_actionOpenAs_triggered();
+    void on_actionImport_triggered();
     void on_actionSave_triggered();
     void on_actionSaveAs_triggered();
     bool isOkToQuit();
@@ -187,6 +190,7 @@ private:
 
     OpenAsDialog openAsDialog = OpenAsDialog(this);
     SettingsDialog settingsDialog = SettingsDialog(this);
+    ImportDialog importDialog = ImportDialog(this);
     ExportDialog exportDialog = ExportDialog(this);
 
     QPointer<D1Pal> pal;

--- a/source/mainwindow.ui
+++ b/source/mainwindow.ui
@@ -122,6 +122,7 @@
     <addaction name="actionOpen"/>
     <addaction name="actionOpenAs"/>
     <addaction name="menuOpen_Recent"/>
+    <addaction name="actionImport"/>
     <addaction name="separator"/>
     <addaction name="actionSave"/>
     <addaction name="actionSaveAs"/>
@@ -249,6 +250,14 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+O</string>
+   </property>
+  </action>
+  <action name="actionImport">
+   <property name="text">
+    <string>Import...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+I</string>
    </property>
   </action>
   <action name="actionSave">


### PR DESCRIPTION
Loads symbols from a TTF/OTF font file into a spritesheet.

---

![image](https://github.com/user-attachments/assets/6e5f1c16-cfa5-470b-8896-d5f003f3f0fa)

![image](https://github.com/user-attachments/assets/e563f101-3748-47a0-80ac-c984ce0308e4)

![image](https://github.com/user-attachments/assets/c06cd4bd-3115-4d0d-a9c8-1caf14c57160)