### PR TITLE
Update upload-artifact CI actions to v4

### DIFF
--- a/.github/workflows/linux-qt5.yml
+++ b/.github/workflows/linux-qt5.yml
@@ -21,7 +21,7 @@ jobs:
       run: cmake --build build -j $(nproc)
     - name: Upload-Package
       if: ${{ !env.ACT }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: D1GraphicsTool-Linux-x64-qt5
         path: build/D1GraphicsTool

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -21,7 +21,7 @@ jobs:
       run: cmake --build build -j $(nproc)
     - name: Upload-Package
       if: ${{ !env.ACT }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: D1GraphicsTool-Linux-x64
         path: build/D1GraphicsTool

--- a/.github/workflows/windows-32.yml
+++ b/.github/workflows/windows-32.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Upload
       if: ${{ !env.ACT }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: D1GraphicsTool-Windows-x86
         path: dist

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Upload
       if: ${{ !env.ACT }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: D1GraphicsTool-Windows-x64
         path: dist


### PR DESCRIPTION
Apparently, v2 has been deprecated.

> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v2`. Learn more: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/