### PR TITLE
Usability improvements for instances of QColorDialog

### DIFF
--- a/source/dialogs/importdialog.cpp
+++ b/source/dialogs/importdialog.cpp
@@ -85,7 +85,9 @@ void ImportDialog::on_fontSymbolsEdit_textChanged(const QString &text)
 void ImportDialog::on_fontColorButton_clicked()
 {
     QColor color = QColorDialog::getColor();
-    setRenderColor(color);
+
+    if (color.isValid())
+        setRenderColor(color);
 }
 
 void ImportDialog::on_importButton_clicked()

--- a/source/dialogs/importdialog.cpp
+++ b/source/dialogs/importdialog.cpp
@@ -84,7 +84,7 @@ void ImportDialog::on_fontSymbolsEdit_textChanged(const QString &text)
 
 void ImportDialog::on_fontColorButton_clicked()
 {
-    QColor color = QColorDialog::getColor();
+    QColor color = QColorDialog::getColor(this->renderColor);
 
     if (color.isValid())
         setRenderColor(color);

--- a/source/dialogs/settingsdialog.cpp
+++ b/source/dialogs/settingsdialog.cpp
@@ -29,7 +29,8 @@ void SettingsDialog::initialize()
 
 void SettingsDialog::on_defaultPaletteColorPushButton_clicked()
 {
-    QColor color = QColorDialog::getColor();
+    QColor color = QColor(ui->defaultPaletteColorLineEdit->text());
+    color = QColorDialog::getColor(color);
 
     if (color.isValid())
         this->ui->defaultPaletteColorLineEdit->setText(color.name());
@@ -37,7 +38,8 @@ void SettingsDialog::on_defaultPaletteColorPushButton_clicked()
 
 void SettingsDialog::on_paletteSelectionBorderColorPushButton_clicked()
 {
-    QColor color = QColorDialog::getColor();
+    QColor color = QColor(ui->paletteSelectionBorderColorLineEdit->text());
+    color = QColorDialog::getColor(color);
 
     if (color.isValid())
         this->ui->paletteSelectionBorderColorLineEdit->setText(color.name());

--- a/source/dialogs/settingsdialog.cpp
+++ b/source/dialogs/settingsdialog.cpp
@@ -30,13 +30,17 @@ void SettingsDialog::initialize()
 void SettingsDialog::on_defaultPaletteColorPushButton_clicked()
 {
     QColor color = QColorDialog::getColor();
-    this->ui->defaultPaletteColorLineEdit->setText(color.name());
+
+    if (color.isValid())
+        this->ui->defaultPaletteColorLineEdit->setText(color.name());
 }
 
 void SettingsDialog::on_paletteSelectionBorderColorPushButton_clicked()
 {
     QColor color = QColorDialog::getColor();
-    this->ui->paletteSelectionBorderColorLineEdit->setText(color.name());
+
+    if (color.isValid())
+        this->ui->paletteSelectionBorderColorLineEdit->setText(color.name());
 }
 
 void SettingsDialog::on_settingsOkButton_clicked()

--- a/source/widgets/palettewidget.cpp
+++ b/source/widgets/palettewidget.cpp
@@ -862,11 +862,16 @@ void PaletteWidget::on_colorLineEdit_returnPressed()
 void PaletteWidget::on_colorPickPushButton_clicked()
 {
     QColor color = QColorDialog::getColor();
+    if (!color.isValid())
+        return;
+
     QColor colorEnd;
     if (this->selectedFirstColorIndex == this->selectedLastColorIndex) {
         colorEnd = color;
     } else {
         colorEnd = QColorDialog::getColor();
+        if (!colorEnd.isValid())
+            return;
     }
 
     // Build color editing command and connect it to the current palette widget

--- a/source/widgets/palettewidget.cpp
+++ b/source/widgets/palettewidget.cpp
@@ -861,7 +861,8 @@ void PaletteWidget::on_colorLineEdit_returnPressed()
 
 void PaletteWidget::on_colorPickPushButton_clicked()
 {
-    QColor color = QColorDialog::getColor();
+    QColor color = this->pal->getColor(this->selectedFirstColorIndex);
+    color = QColorDialog::getColor(color);
     if (!color.isValid())
         return;
 
@@ -869,7 +870,8 @@ void PaletteWidget::on_colorPickPushButton_clicked()
     if (this->selectedFirstColorIndex == this->selectedLastColorIndex) {
         colorEnd = color;
     } else {
-        colorEnd = QColorDialog::getColor();
+        colorEnd = this->pal->getColor(this->selectedLastColorIndex);
+        colorEnd = QColorDialog::getColor(colorEnd);
         if (!colorEnd.isValid())
             return;
     }


### PR DESCRIPTION
Checking if the color is valid enables us to detect if the user canceled the color dialog, ignoring the result instead of replacing the color with black. Passing the current color as the initial color makes it easier to make minute adjustments.